### PR TITLE
Fixed the position of <children>

### DIFF
--- a/setup/kubernetes/index.md
+++ b/setup/kubernetes/index.md
@@ -29,9 +29,11 @@ deprecated features before they are removed from new versions of Kubernetes.
   https://kubernetes.io/docs/setup/release/version-skew-policy/
 [installation guide]: ../installation.md
 
+<children></children>
+
 ## Incompatible Kubernetes distributions
 
 - [DigitalOcean Kubernetes](https://www.digitalocean.com/products/kubernetes/)
   does not support Coder with [CVMs](../../admin/workspace-management/cvms).
 
-<children></children>
+


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39938037/136853990-15a6087b-cfa8-46b9-876c-6de2779a07ba.png)
The section surrounded in red was supposed to be above the `Incompatible Kubernetes distribution`
I tried to fix this.