### PR TITLE
fix(organizations): org admin -> org manager typo

### DIFF
--- a/admin/access-control/organizations.md
+++ b/admin/access-control/organizations.md
@@ -36,7 +36,7 @@ Please note that roles are defined per organization. Therefore, assigning
 someone as an organization manager does not change their role in another
 organization.
 
-### Organization admin permissions
+### Organization manager permissions
 
 <table>
     <thead>


### PR DESCRIPTION
We don't have the concept of an "org admin" in the product, only org "manager" and org "member":

![org-roles](https://user-images.githubusercontent.com/11184711/138495253-063f11b2-11d1-4f33-9b6c-e31efd9caebc.JPG)
