### PR TITLE
fix: add line for RStudio on https deployments

### DIFF
--- a/workspaces/editors.md
+++ b/workspaces/editors.md
@@ -295,6 +295,9 @@ RStudio:
    RUN echo "server-data-dir=/tmp/rstudio" >> /etc/rstudio/rserver.conf
    RUN echo "www-frame-origin=same" >> /etc/rstudio/rserver.conf
 
+   # Remove the following line if you do not run Coder on https
+   RUN echo "server-add-header=X-Forwarded-Proto: https" >> /etc/rstudio/rserver.conf
+
    # Assign password "rstudio" to coder user.
    RUN echo 'coder:rstudio' | chpasswd
 


### PR DESCRIPTION
In some deployments, this line is necessary to avoid an insecure redirect that prevents RStudio from rendering. In others, it will be harmless.

Since we don't maintain an RStudio image, I think this is the only area we need to change it. Let me know if I'm missing something.