### PR TITLE
Devurl public definition

### DIFF
--- a/admin/devurls.md
+++ b/admin/devurls.md
@@ -41,6 +41,8 @@ the rule manually to the ingress.
           servicePort: 8080
 ```
 
+***Note:*** As of the 1.26.0 release, you can set a constant suffix for all dev URLs (e.g., `*-suffix.coder.io`).  This feature helps organizations that may encure expense and delay in creating multiple wildcard DNS records.
+
 ### Step 2: Modify the wildcard DNS record
 
 The final step to enabling dev URLs is to update your wildcard DNS record. Get

--- a/admin/devurls.md
+++ b/admin/devurls.md
@@ -3,8 +3,8 @@ title: "Dev URLs"
 description: Learn how to configure dev URL support for a Coder deployment.
 ---
 
-Developer (Dev) URLs allow users to access the ports of services they develop
-within their workspace. However, before individual developers can set up dev
+Developer (dev) URLs allow users to access the ports of running applications they develop
+within their workspace. Coder listens for the running applications on the specified ports and surface a link to open the running application.  However, before individual developers can set up dev
 URLs, an administrator must configure and enable dev URL usage.
 
 ## Before you proceed

--- a/admin/devurls.md
+++ b/admin/devurls.md
@@ -3,9 +3,13 @@ title: "Dev URLs"
 description: Learn how to configure dev URL support for a Coder deployment.
 ---
 
-Developer (dev) URLs allow users to access the ports of running applications they develop
-within their workspace. Coder listens for the running applications on the specified ports and surface a link to open the running application.  However, before individual developers can set up dev
-URLs, an administrator must configure and enable dev URL usage.
+Developer (dev) URLs allow users to access the ports of running applications
+they develop within their workspace. Coder listens for the applications running
+on the specified ports and provides a browser link that can be used to access
+the application.
+
+Before individual developers can set up dev URLs, an administrator must
+configure and enable dev URL usage.
 
 ## Before you proceed
 
@@ -41,7 +45,10 @@ the rule manually to the ingress.
           servicePort: 8080
 ```
 
-***Note:*** As of the 1.26.0 release, you can set a constant suffix for all dev URLs (e.g., `*-suffix.coder.io`).  This feature helps organizations that may encure expense and delay in creating multiple wildcard DNS records.
+> Beginning with Coder version `1.26.0`, you can set a constant suffix for all
+> dev URLs (e.g., `*-suffix.coder.io`). This feature helps organizations that
+> may incur expenses and delays due to the need for multiple wildcard DNS
+> records.
 
 ### Step 2: Modify the wildcard DNS record
 

--- a/workspaces/devurls.md
+++ b/workspaces/devurls.md
@@ -4,7 +4,9 @@ description: Learn how to access HTTP services running inside your workspace.
 ---
 
 Developer (dev) URLs allow you to access the web services you're developing in
-your workspace.  Once defined, Coder listens for an HTTP application running on the port specified in the dev URL and renders a link to view the application in a browser.
+your workspace. Once defined, Coder listens for an application running on the
+port specified in the dev URL and renders a browser link you can use to view the
+application.
 
 > You must have [dev URLs enabled](../admin/devurls.md) in your installation.
 
@@ -13,10 +15,11 @@ your workspace.  Once defined, Coder listens for an HTTP application running on 
 You can create a dev URL from the workspace overview page.
 
 In the **Dev URLs** section, click **Add Port**. First, provide the **port**
-number for your application and a friendly **name** for the dev URL (optional). Next,
-indicate who can **access** the dev URL and the **internal server scheme** (e.g.,
-whether Coder should use HTTP or HTTPS when proxying requests to the internal
-server).
+number for your application and a friendly **name** for the dev URL (optional).
+
+Next, indicate who should be able to **access** the dev URL and the **internal
+server scheme** (e.g., whether Coder should use HTTP or HTTPS when proxying
+requests to the internal server).
 
 ![Create a dev URL](../assets/workspaces/create-devurl.png)
 
@@ -25,17 +28,19 @@ server).
 You can set the access level for each dev URL:
 
 - **Private** - Only the owner of the workspace can access the dev URL
-- **Organization** - Anyone in the same Coder organization as the workspace can access
-  the dev URL
+- **Organization** - Anyone in the same Coder organization as the workspace can
+  access the dev URL
 - **Authorized Users** - Anyone logged in to your Coder instance can access the
   dev URL
-- **Public** - Anyone outside the Coder deployment's network can access the dev URL (organization-defined firewall rules and VPNs can restrict access)
+- **Public** - Anyone outside the Coder deployment's network can access the dev
+  URL (organization-defined firewall rules and VPNs can still restrict access)
 
-## Using Dev URLs
+## Using dev URLs
 
 To access and manage a dev URL, you can click:
 
-- The **Open in browser** icon to the left of the dev URL name to launch a new browser window
+- The **Open in browser** icon to the left of the dev URL name to launch a new
+  browser window
 - The **Copy URL** action to copy the dev URL for sharing
 - The **Edit URL** action to edit the dev URL
 - The **Delete URL** action to delete the dev URL

--- a/workspaces/devurls.md
+++ b/workspaces/devurls.md
@@ -4,7 +4,7 @@ description: Learn how to access HTTP services running inside your workspace.
 ---
 
 Developer (dev) URLs allow you to access the web services you're developing in
-your workspace.
+your workspace.  Once defined, Coder listens for an HTTP application running on the port specified in the dev URL and renders a link to view the application in a browser.
 
 > You must have [dev URLs enabled](../admin/devurls.md) in your installation.
 
@@ -13,8 +13,8 @@ your workspace.
 You can create a dev URL from the workspace overview page.
 
 In the **Dev URLs** section, click **Add Port**. First, provide the **port**
-number you want to be used and a friendly **name** for the URL (optional). Next,
-indicate who can **access** the URL and the **internal server scheme** (e.g.,
+number for your application and a friendly **name** for the dev URL (optional). Next,
+indicate who can **access** the dev URL and the **internal server scheme** (e.g.,
 whether Coder should use HTTP or HTTPS when proxying requests to the internal
 server).
 
@@ -24,21 +24,23 @@ server).
 
 You can set the access level for each dev URL:
 
-- **Private** - Only the owner of the workspace can access the URL
-- **Organization** - Anyone in the same organization as the workspace can access
-  the URL
+- **Private** - Only the owner of the workspace can access the dev URL
+- **Organization** - Anyone in the same Coder organization as the workspace can access
+  the dev URL
 - **Authorized Users** - Anyone logged in to your Coder instance can access the
-  URL
-- **Public** - Anyone on the internet can access the URL
+  dev URL
+- **Public** - Anyone outside the Coder deployment's network can access the dev URL (organization-defined firewall rules and VPNs can restrict access)
 
-## Using dev URLs
+## Using Dev URLs
 
-To access a dev URL, you can click:
+To access and manage a dev URL, you can click:
 
-- The **Open in browser** icon to launch a new browser window
-- The **Copy** button to copy the URL for sharing
+- The **Open in browser** icon to the left of the dev URL name to launch a new browser window
+- The **Copy URL** action to copy the dev URL for sharing
+- The **Edit URL** action to edit the dev URL
+- The **Delete URL** action to delete the dev URL
 
-![Dev URLs List](../assets/workspaces/devurls.png)
+![Dev URLs List](../assets/workspaces/create-devurl.png)
 
 ### Direct access
 
@@ -47,13 +49,13 @@ There are two ways for you to construct dev URLs.
 If you provided a name for the dev URL when you created it:
 
 ```text
-<name>-<username>.domain
+<name>--<username>.domain
 ```
 
 If you didn't provide a name for the dev URL when you created it:
 
 ```text
-<port>-<workspace_name>-<username>.domain
+<port>--<workspace_name>-<username>.domain
 ```
 
 For example, let's say that you've created a dev URL for port `8080`. Also:
@@ -63,10 +65,10 @@ For example, let's say that you've created a dev URL for port `8080`. Also:
 - Workspace: `my-project`
 
 If you didn't name your dev URL, then your URL is
-`8080-my-project-user.acme.com`.
+`8080--my-project-user.acme.com`.
 
 If, however, you named the dev URL `reactproject`, then your URL is
-`reactproject-user.acme.com`.
+`reactproject--user.acme.com`.
 
 If you access a dev URL that hasn't been created, Coder automatically adds it to
 your dev URL list on the dashboard and sets the access level to **Private**.

--- a/workspaces/ssh.md
+++ b/workspaces/ssh.md
@@ -71,5 +71,5 @@ ssh -L [localport]:localhost:[remoteport] coder.[workspace]
 `localport` is the port you want to use on your local machine (e.g.,
 `localhost:3000`), and `remoteport` matches the `port` of your dev URL.
 
-After SSH port forwarding is configured, you can access the dev URL in a browser (e.g.,
-`http://localhost:3000`)
+After SSH port forwarding is configured, you can access the dev URL (e.g.,
+`http://localhost:3000`) in a browser.

--- a/workspaces/ssh.md
+++ b/workspaces/ssh.md
@@ -62,7 +62,7 @@ To access your server via SSH port forwarding:
 1. [Create a dev URL](devurls.md)
 1. Run `coder config-ssh` using the Coder CLI
 
-Once done, you can access the dev URL port using:
+Once done, you can configure the dev URL port using:
 
 ```console
 ssh -L [localport]:localhost:[remoteport] coder.[workspace]
@@ -70,3 +70,6 @@ ssh -L [localport]:localhost:[remoteport] coder.[workspace]
 
 `localport` is the port you want to use on your local machine (e.g.,
 `localhost:3000`), and `remoteport` matches the `port` of your dev URL.
+
+After SSH port forwarding is configured, you can access the dev URL in a browser (e.g.,
+`http://localhost:3000`)


### PR DESCRIPTION
Updated dev URL docs to latest release behavior.

Also updated for better definitions of what dev URLs are, how they operate, consistency, clearer examples, current release screenshot, and better clarity with port forwarding.

Also mentioned constant suffix feature in 1.26.0