### PR TITLE
fix: rstudio dockerfile example

### DIFF
--- a/workspaces/editors.md
+++ b/workspaces/editors.md
@@ -213,9 +213,7 @@ RStudio:
    gdebi-core
 
    # Install RStudio
-   RUN wget
-   https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.4.1717-amd64.deb
-   && \
+   RUN wget https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.4.1717-amd64.deb && \
    gdebi --non-interactive rstudio-server-1.4.1717-amd64.deb
 
    # Create coder user


### PR DESCRIPTION
I tried copying it but there are extra newlines that cause it to break.

```
Sending build context to Docker daemon  3.072kB
Error response from daemon: dockerfile parse error line 19: unknown instruction: HTTPS://DOWNLOAD2.RSTUDIO.ORG/SERVER/BIONIC/AMD64/RSTUDIO-SERVER-1.4.1717-AMD64.DEB
```