### PR TITLE
chore: remove redundant timescale note

### DIFF
--- a/setup/air-gapped/index.md
+++ b/setup/air-gapped/index.md
@@ -70,20 +70,15 @@ platform images are hosted in Coder's Docker Hub repo.
 1. Pull the images for the Coder platform from the following Docker Hub
    locations:
 
+   - [coder-service](https://hub.docker.com/r/coderenvs/coder-service)
+
+   - [envbox](https://hub.docker.com/r/coderenvs/envbox)
+
+   - (Optional) [timescale](https://hub.docker.com/r/coderenvs/timescale)
+
    > Timescale is an internal database meant for evaluation deployments. It is
    > not It is not recommended to run this service in production. Connect to an
    > external Postgres database for production deployments.
-
-   [coder-service](https://hub.docker.com/r/coderenvs/coder-service)
-
-   [envbox](https://hub.docker.com/r/coderenvs/envbox)
-
-   [timescale](https://hub.docker.com/r/coderenvs/timescale) (**Note**: We
-   recommend you only use timescale for evaluation purposes if you don't have an
-   external PostgreSQL database available. For production environments, we
-   strongly recommend that you use an external PostgreSQL database; the
-   installation section will cover more on updating your Helm values with your
-   database information.)
 
    You can pull each of these images from their `coderenvs/<img-name>:<version>`
    registry location using the image's name and Coder version:

--- a/setup/air-gapped/index.md
+++ b/setup/air-gapped/index.md
@@ -76,8 +76,8 @@ platform images are hosted in Coder's Docker Hub repo.
 
    - (Optional) [timescale](https://hub.docker.com/r/coderenvs/timescale)
 
-   > Timescale is an internal database meant for evaluation deployments. It is
-   > not It is not recommended to run this service in production. Connect to an
+   > Timescale is an internal database meant for evaluation deployments. We
+   > do not recommend running this service in production. Connect to an
    > external Postgres database for production deployments.
 
    You can pull each of these images from their `coderenvs/<img-name>:<version>`


### PR DESCRIPTION
was skimming through the air-gapped docs and noticed a redundant paragraph. this PR cleans things up.