### PR TITLE
fix: remove dev url var quotations

### DIFF
--- a/guides/tls-certificates/docker-tls.md
+++ b/guides/tls-certificates/docker-tls.md
@@ -160,7 +160,7 @@ coder:
   ports:
     - 7080:7080
   environment:
-    - DEVURL_HOST="*.<your-domain.com>"
+    - DEVURL_HOST=*.<your-domain.com>
 ```
 
 > The `~/letsecnrypt:/letsencrypt/` volume definition is required only if you


### PR DESCRIPTION
removing the `DEVURL_HOST` quotations in the Docker Compose file. a prospect reported this threw an error where unnecessary characters were added to newly created dev URLs.