### PR TITLE
fix: clarify password reset process

### DIFF
--- a/admin/access-control/password-reset.md
+++ b/admin/access-control/password-reset.md
@@ -27,7 +27,7 @@ If you need to reset the password for a site admin, you can do so using coderd's
 > [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) dependency
 > installed from when you first set up Coder; if not, please sure to install it
 > before proceeding. If you are using Docker, follow
-> [these instructions](../../setup/docker#admin-password) instead
+> [these instructions](../../setup/docker#admin-password) instead.
 
 To reset the password, run the following in the terminal:
 

--- a/admin/access-control/password-reset.md
+++ b/admin/access-control/password-reset.md
@@ -26,7 +26,8 @@ If you need to reset the password for a site admin, you can do so using coderd's
 > You should have the
 > [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) dependency
 > installed from when you first set up Coder; if not, please sure to install it
-> before proceeding.
+> before proceeding. If you are using Docker, follow
+> [these instructions](../../setup/docker#admin-password) instead
 
 To reset the password, run the following in the terminal:
 

--- a/guides/troubleshooting/admin-pwd.md
+++ b/guides/troubleshooting/admin-pwd.md
@@ -3,8 +3,9 @@ title: Admin password reset
 description: Learn how to resolve issues with resetting your admin password.
 ---
 
-When resetting your Coder admin password in the terminal, you may encounter the
-following error:
+When
+[resetting your Coder admin password](../../admin/access-control/password-reset.md#resetting-the-site-admin-password)
+in the terminal, you may encounter the following error:
 
 ```console
 error: unable to upgrade connection: error dialing backend: remote error: tls:

--- a/setup/docker.md
+++ b/setup/docker.md
@@ -93,8 +93,8 @@ docker run --rm -it -p 7080:7080 -v /var/run/docker.sock:/var/run/docker.sock -v
 
 ## Admin password
 
-If you want to set your admin password, perhaps if you forgot it, use the
-`-e SUPER_ADMIN_PASSWORD=<password>` flag with `docker run`.
+If you want to set (or reset) your admin password, use the
+`-e SUPER_ADMIN_PASSWORD=<password>` flag with the `docker run` command.
 
 ## Scaling
 

--- a/setup/docker.md
+++ b/setup/docker.md
@@ -91,6 +91,11 @@ For example:
 docker run --rm -it -p 7080:7080 -v /var/run/docker.sock:/var/run/docker.sock -v ~/.coder:/var/run/coder -e DEVURL_HOST="*.mycompany.com" codercom/coder:1.25.1
 ```
 
+## Admin password
+
+If you want to set your admin password, perhaps if you forgot it, use the
+`-e SUPER_ADMIN_PASSWORD=<password>` flag with `docker run`.
+
 ## Scaling
 
 Coder for Docker is limited by the resources of the machine on which it runs. We


### PR DESCRIPTION
Our password reset docs were for Kubernetes only. I added details in the Coder for Docker section. 

When searching "reset password," there is also a troubleshooting guide. I added a link that references the original instructions that aims to help users navigate to the correct page