### PR TITLE
add ebpf-required config

### DIFF
--- a/admin/workspace-management/process-logging.md
+++ b/admin/workspace-management/process-logging.md
@@ -39,7 +39,7 @@ machine in question:
 cat /proc/config.gz | gunzip | grep CONFIG_DEBUG_INFO_BTF
 ```
 
-```
+```console
 cat "/boot/config-$(uname -r)" | grep CONFIG_DEBUG_INFO_BTF
 ```
 

--- a/admin/workspace-management/process-logging.md
+++ b/admin/workspace-management/process-logging.md
@@ -33,7 +33,7 @@ Use of the workspace process logging functionality requires a host Linux
 kernel >= 5.8 with the kernel config `CONFIG_DEBUG_INFO_BTF=y` enabled.
 
 To validate this config is enabled, run either of the following commands on the
-machine in question:
+nodes directly (not from within a workspace):
 
 ```console
 cat /proc/config.gz | gunzip | grep CONFIG_DEBUG_INFO_BTF

--- a/admin/workspace-management/process-logging.md
+++ b/admin/workspace-management/process-logging.md
@@ -30,7 +30,7 @@ The core of this feature is also open source and can be found in the
 ## Requirements
 
 Use of the workspace process logging functionality requires a host Linux
-kernel >= 5.8.
+kernel >= 5.8 with the environment variable `CONFIG_DEBUG_INFO_BTF=y` set.
 
 ## Enable workspace process logging
 

--- a/admin/workspace-management/process-logging.md
+++ b/admin/workspace-management/process-logging.md
@@ -33,7 +33,7 @@ Use of the workspace process logging functionality requires a host Linux
 kernel >= 5.8 with the kernel config `CONFIG_DEBUG_INFO_BTF=y` enabled.
 
 To validate this config is enabled, run either of the following commands on the
-nodes directly (not from within a workspace):
+nodes directly (*not* from the terminal within a workspace):
 
 ```console
 cat /proc/config.gz | gunzip | grep CONFIG_DEBUG_INFO_BTF

--- a/admin/workspace-management/process-logging.md
+++ b/admin/workspace-management/process-logging.md
@@ -30,7 +30,18 @@ The core of this feature is also open source and can be found in the
 ## Requirements
 
 Use of the workspace process logging functionality requires a host Linux
-kernel >= 5.8 with the environment variable `CONFIG_DEBUG_INFO_BTF=y` set.
+kernel >= 5.8 with the kernel config `CONFIG_DEBUG_INFO_BTF=y` enabled.
+
+To validate this config is enabled, run either of the following commands on the
+machine in question:
+
+```console
+cat /proc/config.gz | gunzip | grep CONFIG_DEBUG_INFO_BTF
+```
+
+```
+cat "/boot/config-$(uname -r)" | grep CONFIG_DEBUG_INFO_BTF
+```
 
 ## Enable workspace process logging
 


### PR DESCRIPTION
discovered a particular kernel configuration that is needed to successfully run the `exectrace` sidecar container:

- `CONFIG_DEBUG_INFO_BTF=y`

@deansheather let me know if we should include the command(s) to run to check for this on the host system.