### PR TITLE
chore: enforce concurrency with GitHub feature

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,15 +24,18 @@ permissions:
   security-events: none
   statuses: none
 
+# Cancel in-progress runs for pull requests when developers push
+# additional changes, and serialize builds in branches.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-to-cancel-any-in-progress-job-or-run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-20.04
     steps:
-      - name: Cancel Previous Runs
-        if: github.ref != 'refs/heads/master'
-        uses: styfle/cancel-workflow-action@0.9.1
-
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -18,14 +18,18 @@ permissions:
   security-events: none
   statuses: none
 
+# Cancel in-progress runs for pull requests when developers push
+# additional changes, and serialize builds in branches.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-to-cancel-any-in-progress-job-or-run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   preview:
     name: Preview
     runs-on: ubuntu-20.04
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-
       - name: Checkout m
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,14 +19,18 @@ permissions:
   security-events: none
   statuses: none
 
+# Cancel in-progress runs for pull requests when developers push
+# additional changes, and serialize builds in branches.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-to-cancel-any-in-progress-job-or-run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   production:
     name: Production
     runs-on: ubuntu-20.04
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-
       - name: Checkout m
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Use GitHub's concurrency feature to cancel in-progress builds
on pull request events, and serialize builds for branch push
events.