### PR TITLE
fix: further clarify custom AMI support with EKS

### DIFF
--- a/setup/kubernetes/aws.md
+++ b/setup/kubernetes/aws.md
@@ -180,18 +180,16 @@ as a workspace deployment option, you'll need to
    managedNodeGroups:
      - name: coder-node-group
        amiFamily: Ubuntu2004
-       # Custom AMIs can be used instead of amiFamily
+       # Custom EKS-compatible AMIs can be used instead of amiFamily
        # ami: <your Ubuntu 20.04 AMI ID>
        instanceType: <instance-type>
        minSize: 1
        mazSize: 2
        desiredCapacity: 1
        # Uncomment "overrideBootstrapCommand" if you are using a custom AMI
-       # and replace YOUR_CLUSTER_CA with "certificate-authority-data" from
-       # your kubeconfig
        # overrideBootstrapCommand: |
        #  #!/bin/bash -xe
-       #  sudo /etc/eks/bootstrap.sh --apiserver-endpoint '' --b64-cluster-ca 'YOUR_CLUSTER_CA' '<cluster-name>'
+       #  sudo /etc/eks/bootstrap.sh <YOUR_CLUSTER_NAME>
    ```
 
 > [See here for a list of EKS-compatible Ubuntu AMIs](https://cloud-images.ubuntu.com/docs/aws/eks/)


### PR DESCRIPTION
I found a few more ways to simplify the setup for managedNodeGroups. Apologies for all the construction on this doc today.