### PR TITLE
chore: fix formatting in changelogs

### DIFF
--- a/changelog/1.27.0.md
+++ b/changelog/1.27.0.md
@@ -6,10 +6,8 @@ description: "Released on 01/19/2022"
 ### Breaking changes ❗
 
 - Users upgrading deployments that predate the release of v1.21 should update
-  their Helm values file to reflect Coder's [updated
-  schema](https://github.com/coder/enterprise-helm/blob/1.27.0/values.yaml) if
- they haven't already. More specifically, users must change the following
-  values:
+  their Helm values file to reflect Coder's [updated schema] if they haven't
+  already. More specifically, users must change the following values:
 
   - `cemanager` --> `coderd`
   - `cemanager.replicas` --> `coderd.replicas`
@@ -17,21 +15,33 @@ description: "Released on 01/19/2022"
   - `cemanager.resources` --> `coderd.resources`
   - `devurls.host` --> `coderd.devurlsHost`
   - `ingress.loadBalancerIP` --> `coderd.serviceSpec.loadBalancerIP`
-  - `ingress.loadBalancerSourceRanges` --> `coderd.serviceSpec.loadBalancerSourceRanges`
-  - `ingress.service.externalTrafficPolicy` --> `coderd.serviceSpec.externalTrafficPolicy`
+  - `ingress.loadBalancerSourceRanges` -->
+    `coderd.serviceSpec.loadBalancerSourceRanges`
+  - `ingress.service.externalTrafficPolicy` -->
+    `coderd.serviceSpec.externalTrafficPolicy`
   - `ingress.tls.hostSecretName` --> `coderd.tls.hostSecretName`
   - `ingress.tls.devurlsHostSecretName` --> `coderd.tls.devurlsHostSecretName`
   - `storageClassName` --> `postgres.default.storageClassName`
   - `timescale.image` --> `postgres.default.image`
   - `timescale.resources` --> `postgres.default.resources`
-  - `timescale.resources.requests.storage` --> `postgres.default.resources.requests.storage`
+  - `timescale.resources.requests.storage` -->
+    `postgres.default.resources.requests.storage`
   - `postgres.useDefault` --> `postgres.default.enable`
   - `deploymentAnnotations` --> `services.annotations`
   - `serviceTolerations` --> `services.tolerations`
   - `clusterDomainSuffix` --> `services.clusterDomainSuffix`
   - `serviceType` --> `services.type`
-  - `serviceAccount.annotations` --> `coderd.builtinProviderServiceAccount.annotations`
+  - `serviceAccount.annotations` -->
+    `coderd.builtinProviderServiceAccount.annotations`
   - `serviceAccount.labels` --> `coderd.builtinProviderServiceAccount.labels`
+
+<!-- Turn off linting to avoid changing the link -->
+<!-- markdownlint-disable MD044 -->
+
+[updated schema]:
+  https://github.com/coder/enterprise-helm/blob/1.27.0/values.yaml
+
+<!-- markdownlint-enable MD044 -->
 
 ### Features ✨
 

--- a/changelog/1.27.1.md
+++ b/changelog/1.27.1.md
@@ -6,10 +6,8 @@ description: "Released on 01/31/2022"
 ### Breaking changes ❗
 
 - Users upgrading deployments that predate the release of v1.21 should update
-  their Helm values file to reflect Coder's [updated
-  schema](https://github.com/coder/enterprise-helm/blob/1.27.0/values.yaml) if
- they haven't already. More specifically, users must change the following
-  values:
+  their Helm values file to reflect Coder's [updated schema] if they haven't
+  already. More specifically, users must change the following values:
 
   - `cemanager` --> `coderd`
   - `cemanager.replicas` --> `coderd.replicas`
@@ -17,21 +15,33 @@ description: "Released on 01/31/2022"
   - `cemanager.resources` --> `coderd.resources`
   - `devurls.host` --> `coderd.devurlsHost`
   - `ingress.loadBalancerIP` --> `coderd.serviceSpec.loadBalancerIP`
-  - `ingress.loadBalancerSourceRanges` --> `coderd.serviceSpec.loadBalancerSourceRanges`
-  - `ingress.service.externalTrafficPolicy` --> `coderd.serviceSpec.externalTrafficPolicy`
+  - `ingress.loadBalancerSourceRanges` -->
+    `coderd.serviceSpec.loadBalancerSourceRanges`
+  - `ingress.service.externalTrafficPolicy` -->
+    `coderd.serviceSpec.externalTrafficPolicy`
   - `ingress.tls.hostSecretName` --> `coderd.tls.hostSecretName`
   - `ingress.tls.devurlsHostSecretName` --> `coderd.tls.devurlsHostSecretName`
   - `storageClassName` --> `postgres.default.storageClassName`
   - `timescale.image` --> `postgres.default.image`
   - `timescale.resources` --> `postgres.default.resources`
-  - `timescale.resources.requests.storage` --> `postgres.default.resources.requests.storage`
+  - `timescale.resources.requests.storage` -->
+    `postgres.default.resources.requests.storage`
   - `postgres.useDefault` --> `postgres.default.enable`
   - `deploymentAnnotations` --> `services.annotations`
   - `serviceTolerations` --> `services.tolerations`
   - `clusterDomainSuffix` --> `services.clusterDomainSuffix`
   - `serviceType` --> `services.type`
-  - `serviceAccount.annotations` --> `coderd.builtinProviderServiceAccount.annotations`
+  - `serviceAccount.annotations` -->
+    `coderd.builtinProviderServiceAccount.annotations`
   - `serviceAccount.labels` --> `coderd.builtinProviderServiceAccount.labels`
+
+<!-- Turn off linting to avoid changing the link -->
+<!-- markdownlint-disable MD044 -->
+
+[updated schema]:
+  https://github.com/coder/enterprise-helm/blob/1.27.0/values.yaml
+
+<!-- markdownlint-enable MD044 -->
 
 ### Features ✨
 


### PR DESCRIPTION
formatting is no longer broken:

<img width="927" alt="Screen Shot 2022-02-16 at 2 35 41 PM" src="https://user-images.githubusercontent.com/16521651/154352605-5eec8609-33f2-4263-9b7b-61cabf3a2b3c.png">
