### PR TITLE
chore: add 1.28.1 changelog

### DIFF
--- a/changelog/1.28.1.md
+++ b/changelog/1.28.1.md
@@ -5,18 +5,20 @@ description: "Released on 02/23/2022"
 
 ### Breaking changes ❗
 
-There are no breaking changes in 1.28.1.
+- There are no breaking changes in 1.28.1.
 
 ### Features ✨
 
-There are no new features in 1.28.1.
+- infra: relaxed the Kubernetes version requirement. Coder requires v1.19 or
+  later, though you'll see warning messages if you're running v1.19 or v1.20. We
+  recommend running v1.21 (or later) if possible.
 
 ### Bug fixes 🐛
 
-- infra: fixed issue regarding mTLS not working with Git providers.
-- infra: fixed issue regarding mTLS not working with Docker registries.
-- infra: fixed issue with `coderd` intermittently crashing
+- infra: fixed issue regarding mTLS not working with Git providers and Docker
+  registries.
+- infra: fixed issue with `coderd` intermittently crashing.
 
 ### Security updates 🔐
 
-There are no security updates in 1.281.
+There are no security updates in 1.28.1.

--- a/changelog/1.28.1.md
+++ b/changelog/1.28.1.md
@@ -5,7 +5,7 @@ description: "Released on 02/23/2022"
 
 ### Breaking changes ❗
 
-- There are no breaking changes in 1.28.1.
+There are no breaking changes in 1.28.1.
 
 ### Features ✨
 

--- a/changelog/1.28.1.md
+++ b/changelog/1.28.1.md
@@ -10,8 +10,9 @@ description: "Released on 02/23/2022"
 ### Features ✨
 
 - infra: relaxed the Kubernetes version requirement. Coder requires v1.21 or
-  later. If you opt to use v1.19 or v1.20, you'll see warning messages during
-  the installation process; Coder does not allow the use of v1.18 or earlier.
+  later and does not support earlier versions. If you opt to use v1.19 or v1.20,
+  you'll see warning messages during the installation process. Coder does not
+  allow the use of v1.18 or earlier.
 
 ### Bug fixes 🐛
 

--- a/changelog/1.28.1.md
+++ b/changelog/1.28.1.md
@@ -1,0 +1,22 @@
+---
+title: "1.28.1"
+description: "Released on 02/23/2022"
+---
+
+### Breaking changes ❗
+
+There are no breaking changes in 1.28.1.
+
+### Features ✨
+
+There are no new features in 1.28.1.
+
+### Bug fixes 🐛
+
+- infra: fixed issue regarding mTLS not working with Git providers.
+- infra: fixed issue regarding mTLS not working with Docker registries.
+- infra: fixed issue with `coderd` intermittently crashing
+
+### Security updates 🔐
+
+There are no security updates in 1.281.

--- a/changelog/1.28.1.md
+++ b/changelog/1.28.1.md
@@ -9,9 +9,9 @@ description: "Released on 02/23/2022"
 
 ### Features ✨
 
-- infra: relaxed the Kubernetes version requirement. Coder requires v1.19 or
-  later, though you'll see warning messages if you're running v1.19 or v1.20. We
-  recommend running v1.21 (or later) if possible.
+- infra: relaxed the Kubernetes version requirement. Coder requires v1.21 or
+  later. If you opt to use v1.19 or v1.20, you'll see warning messages during
+  the installation process; Coder does not allow the use of v1.18 or earlier.
 
 ### Bug fixes 🐛
 

--- a/manifest.json
+++ b/manifest.json
@@ -535,7 +535,12 @@
       "path": "./changelog/index.md",
       "children": [
         {
-          "path": "./changelog/1.28.0.md"
+          "path": "./changelog/1.28.0.md",
+          "children": [
+            {
+              "path": "./changelog/1.28.1.md"
+            }
+          ]
         },
         {
           "path": "./changelog/1.27.0.md",


### PR DESCRIPTION
might need to add mention re: relaxing K8s requirement ~(would also need to update 1.28.0 changelog so that it's not listed as a breaking change)~