### PR TITLE
Update preview

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -11,18 +11,13 @@ jobs:
     name: Preview
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: chrnorm/deployment-action@releases/v1
+        name: Create GitHub deployment
+        id: deployment
         with:
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
-          
-      - name: Update Deployment
-        run: ./ci/scripts/github_deployment.sh update
-        env:
-          GITHUB_DEPLOYMENT: ${{ steps.deployment.outputs.id }}
-          GITHUB_TOKEN: ${{ github.token }}
-          DEPLOY_STATUS: success
-          DEPLOY_URL: https://coder.com/docs/coder/${{ github.event.pull_request.head.sha }}
+          token: "${{ github.token }}"
+          target_url:  https://coder.com/docs/coder/${{ github.event.pull_request.head.sha }}
+          environment: preview
 
       - name: Comment Credentials
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -11,6 +11,11 @@ jobs:
     name: Preview
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          
       - name: Update Deployment
         run: ./ci/scripts/github_deployment.sh update
         env:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -25,6 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set outputs
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
       - name: Comment Credentials
         uses: marocchino/sticky-pull-request-comment@v2
         with:
@@ -32,7 +36,7 @@ jobs:
           message: |
             ✨ Coder.com for PR #${{ github.event.number }} deployed! It will be updated on every commit.
 
-            * _Host_: https://coder.com/docs/coder/${{ github.event.pull_request.head.sha }}
+            * _Host_: https://coder.com/docs/coder/${{ steps.vars.outputs.sha_short }}
             * _Last deploy status_: success
             * _Commit_: ${{ github.event.pull_request.head.sha }}
             * _Workflow status_: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update Deployment
+        run: ./ci/scripts/github_deployment.sh update
         env:
           GITHUB_DEPLOYMENT: ${{ steps.deployment.outputs.id }}
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -6,6 +6,18 @@ on:
       - main
       - "release-*"
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: write
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   preview:
     name: Preview

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -12,14 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      
-      - uses: chrnorm/deployment-action@releases/v1
-        name: Create GitHub deployment
-        id: deployment
-        with:
-          token: "${{ github.token }}"
-          target_url:  https://coder.com/docs/coder/${{ github.event.pull_request.head.sha }}
-          environment: preview
 
       - name: Comment Credentials
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -6,96 +6,26 @@ on:
       - main
       - "release-*"
 
-permissions:
-  actions: none
-  checks: none
-  contents: read
-  deployments: none
-  issues: none
-  packages: none
-  pull-requests: write
-  repository-projects: none
-  security-events: none
-  statuses: none
-
-# Cancel in-progress runs for pull requests when developers push
-# additional changes, and serialize builds in branches.
-# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-to-cancel-any-in-progress-job-or-run
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   preview:
     name: Preview
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout m
-        uses: actions/checkout@v3
-        with:
-          repository: cdr/m
-          ref: refs/heads/master
-          ssh-key: ${{ secrets.READONLY_M_DEPLOY_KEY }}
-          submodules: true
-          fetch-depth: 0
-
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 14
-
-      - name: Cache Node Modules
-        uses: actions/cache@v2
-        with:
-          path: "/node_modules"
-          key: node-${{ hashFiles('yarn.lock') }}
-
-      - name: Create Deployment
-        id: deployment
-        run: ./ci/scripts/github_deployment.sh create
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          DEPLOY_ENVIRONMENT: codercom-preview-docs
-
-      - name: Deploy Preview to Vercel
-        id: preview
-        run: ./ci/scripts/deploy_vercel.sh
-        env:
-          VERCEL_ORG_ID: team_tGkWfhEGGelkkqUUm9nXq17r
-          VERCEL_PROJECT_ID: QmZRucMRh3GFk1817ZgXjRVuw5fhTspHPHKct3JNQDEPGd
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          CODER_DOCS_MAIN_BRANCH: ${{ github.event.pull_request.head.sha }}
-
-      # This ensures the docs site is built properly
-      # as it will sometimes throw a 404 or 500
-      # error if Markdown/parsing errors are present
-      - name: Install node_modules
-        run: yarn install
-      - name: Check docs
-        run: yarn ts-node ./product/coder.com/site/scripts/checkDocs.ts
-        env:
-          BASE_URL: ${{ steps.preview.outputs.url }}
-
       - name: Update Deployment
-        # If we don't specify always, it won't run this check if failed.
-        # This means the deployment would be stuck pending.
-        if: always()
-        run: ./ci/scripts/github_deployment.sh update
         env:
           GITHUB_DEPLOYMENT: ${{ steps.deployment.outputs.id }}
           GITHUB_TOKEN: ${{ github.token }}
-          DEPLOY_STATUS: ${{ steps.preview.outcome }}
-          DEPLOY_URL: ${{ steps.preview.outputs.url }}
+          DEPLOY_STATUS: success
+          DEPLOY_URL: https://coder.com/docs/coder/${{ github.event.pull_request.head.sha }}
 
       - name: Comment Credentials
         uses: marocchino/sticky-pull-request-comment@v2
-        if: always()
         with:
           header: codercom-preview-docs
           message: |
             ✨ Coder.com for PR #${{ github.event.number }} deployed! It will be updated on every commit.
 
-            * _Host_: ${{ steps.preview.outputs.url }}/docs
-            * _Last deploy status_: ${{ steps.preview.outcome }}
+            * _Host_: https://coder.com/docs/coder/${{ github.event.pull_request.head.sha }}
+            * _Last deploy status_: success
             * _Commit_: ${{ github.event.pull_request.head.sha }}
             * _Workflow status_: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -11,6 +11,8 @@ jobs:
     name: Preview
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      
       - uses: chrnorm/deployment-action@releases/v1
         name: Create GitHub deployment
         id: deployment


### PR DESCRIPTION
We don't need to deploy the docs anymore, we can pass the commit hash into the URL to see the changes in preview:
<img width="922" alt="Screen Shot 2022-03-09 at 14 21 32" src="https://user-images.githubusercontent.com/3165839/157496095-c451c91f-232f-4d74-a796-5f36ee19a7c2.png">
