### PR TITLE
JetBrains license activation paste command change

### DIFF
--- a/guides/troubleshooting/activate-jetbrains-licensing.md
+++ b/guides/troubleshooting/activate-jetbrains-licensing.md
@@ -68,8 +68,8 @@ clipboard.
 ## Paste the IDE authentication token
 
 Paste the IDE authentication token back into your already opened JetBrains IDE
-window. If on a Mac, you must type CMD + v followed by Control + v for the paste
-operation to work correctly.
+window. Type CMD + v or Control + v depending on your local OS for the paste
+operation to work correctly. 
 
 ![Paste the token](../../assets/workspaces/7-cmd-v-ctrl-v-auth-token.png)
 


### PR DESCRIPTION
JetBrains updated projector so double keyboard commands are no longer required to paste the JetBrains license IDE token in the activation process. CMD or Control V works fine now.