### PR TITLE
fix(tls): cert-manager installation script

### DIFF
--- a/guides/tls-certificates/cloudDNS.md
+++ b/guides/tls-certificates/cloudDNS.md
@@ -39,7 +39,7 @@ You must have:
 To add cert-manager to your cluster, run:
 
 ```console
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.yaml
 ```
 
 More specifics can be found in the


### PR DESCRIPTION
## Summary

We had an outdated installation script for cert-manager

## See also

https://cert-manager.io/docs/installation/

## Note

We don't have any checks/process in place for checking on this script (ex: parsing it from https://cert-manager.io/docs/installation/). We are prone to getting out of date again without some kind of process around it.