### PR TITLE
replaced kubeapply jetstack cert-manager approach with helm install

### DIFF
--- a/guides/tls-certificates/azureDNS.md
+++ b/guides/tls-certificates/azureDNS.md
@@ -14,10 +14,10 @@ authority.
 > differently from earlier versions of Coder. Ensure that you're reading the
 > docs applicable to your Coder version.
 
-This guide will show you how to install cert-manager v1.4.0 and set up your
-cluster to issue Let's Encrypt certificates for your Coder installation so that
-you can enable HTTPS on your Coder deployment. It will also show you how to
-configure your Coder hostname and dev URLs.
+This guide will show you how to install cert-manager and set up your cluster to
+issue Let's Encrypt certificates for your Coder installation so that you can
+enable HTTPS on your Coder deployment. It will also show you how to configure
+your Coder hostname and dev URLs.
 
 There are three available methods to configuring the Azure DNS DNS01 Challenge
 via cert-manager:
@@ -84,7 +84,7 @@ the domain you're using for your Coder deployment.
    cert-manager:
 
    ```console
-   kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
+   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.yaml
    ```
 
 1. Check that cert-manager installs correctly by running
@@ -300,11 +300,14 @@ However, to use all of the functionality you set up in this tutorial, use the
 following command instead:
 
 ```console
+# be sure to update the `stringValue` placeholder with the
+# proper value for your devurlsHostSecretName and hostSecretName
+
 helm upgrade --install coder coder/coder --namespace coder \
   --version=<CODER_VERSION> \
-  --set coderd.devurlsHost="coder.example.com" \
-  --set coderd.tls.devurlsHostSecretName="coder-certs" \
-  --set coderd.tls.hostSecretName="coder-certs" \
+  --set coderd.devurlsHost="*.coder.example.com" \
+  --set coderd.tls.devurlsHostSecretName="coder-certs-stringValue" \
+  --set coderd.tls.hostSecretName="coder-certs-stringValue" \
   --wait
 ```
 

--- a/guides/tls-certificates/cloudDNS.md
+++ b/guides/tls-certificates/cloudDNS.md
@@ -38,7 +38,7 @@ You must have:
 
 There are two ways to add cert-manager to your Kubernetes cluster.
 
-## Option 1
+## Option 1: `kubectl apply`
 
 Add cert-manager to your cluster
 [using `kubectl apply`](https://cert-manager.io/docs/installation/kubectl/) by
@@ -48,10 +48,10 @@ running:
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.yaml
 ```
 
-## Option 2
+## Option 2: Helm
 
 Add cert-manager to your cluster
-[with Helm](https://cert-manager.io/docs/installation/helm/).
+[using Helm](https://cert-manager.io/docs/installation/helm/).
 
 First, add the Helm repo:
 

--- a/guides/tls-certificates/cloudDNS.md
+++ b/guides/tls-certificates/cloudDNS.md
@@ -207,11 +207,14 @@ However, to use all of the functionality you set up in this tutorial, use the
 following command instead:
 
 ```console
+# be sure to update the `stringValue` placeholder with the
+# proper value for your devurlsHostSecretName and hostSecretName
+
 helm upgrade --install coder coder/coder --namespace coder \
   --version=<CODER_VERSION> \
   --set coderd.devurlsHost="*.coder.example.com" \
-  --set coderd.tls.devurlsHostSecretName="coder-certs" \
-  --set coderd.tls.hostSecretName="coder-certs" \
+  --set coderd.tls.devurlsHostSecretName="coder-certs-stringValue" \
+  --set coderd.tls.hostSecretName="coder-certs-stringValue" \
   --wait
 ```
 

--- a/guides/tls-certificates/cloudDNS.md
+++ b/guides/tls-certificates/cloudDNS.md
@@ -36,10 +36,21 @@ You must have:
 
 ## Step 1: Add cert-manager to your Kubernetes cluster
 
-To add cert-manager to your cluster, run:
+To add cert-manager to your cluster, add the cert-manager helm chart repo
 
 ```console
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
+helm repo add jetstack https://charts.jetstack.io
+```
+
+Install cert-manager and create the namespace too (check for the latest cert-manager version, they change frequently)
+
+```console
+helm install \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --version v1.7.0 \
+  --create-namespace \
+  --set installCRDs=true
 ```
 
 More specifics can be found in the

--- a/guides/tls-certificates/cloudDNS.md
+++ b/guides/tls-certificates/cloudDNS.md
@@ -14,10 +14,10 @@ authority.
 > differently from earlier versions of Coder. Ensure that you're reading the
 > docs applicable to your Coder version.
 
-This guide will show you how to install cert-manager v1.4.0 and set up your
-cluster to issue Let's Encrypt certificates for your Coder installation so that
-you can enable HTTPS on your Coder deployment. It will also show you how to
-configure your Coder hostname and dev URLs.
+This guide will show you how to install cert-manager and set up your cluster to
+issue Let's Encrypt certificates for your Coder installation so that you can
+enable HTTPS on your Coder deployment. It will also show you how to configure
+your Coder hostname and dev URLs.
 
 > We recommend reviewing the official cert-manager
 > [documentation](https://cert-manager.io/docs/) if you encounter any issues or

--- a/guides/tls-certificates/cloudflare.md
+++ b/guides/tls-certificates/cloudflare.md
@@ -14,9 +14,9 @@ authority.
 > differently from earlier versions of Coder. Ensure that you're reading the
 > docs applicable to your Coder version.
 
-This guide will show you how to install cert-manager v1.4.0 and set up your
-cluster to issue Let's Encrypt certificates for your Coder installation so that
-you can enable HTTPS on your Coder deployment.
+This guide will show you how to install cert-manager and set up your cluster to
+issue Let's Encrypt certificates for your Coder installation so that you can
+enable HTTPS on your Coder deployment.
 
 > We recommend reviewing the official cert-manager
 > [documentation](https://cert-manager.io/docs/) if you encounter any issues or
@@ -34,7 +34,7 @@ You must have:
 ## Step 1: Add cert-manager to your Kubernetes cluster
 
 ```console
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.yaml
 ```
 
 More specifics can be found in the
@@ -201,14 +201,16 @@ kubectl apply -f certificate.yaml
 ## Step 4: Configure Coder to issue and use the certificates
 
 If you're using the default LoadBalancer to access Coder, you can use the
-following helm values to use the certificate.
+following Helm values to use the certificate.
 
 ```yaml
+# be sure to update the `stringValue` placeholder with the
+# proper value for your devurlsHostSecretName and hostSecretName
 coderd:
   devurlsHost: "*.coder.example.com"
   tls:
-    devurlsHostSecretName: "coder-certs"
-    hostSecretName: "coder-certs"
+    devurlsHostSecretName: "coder-certs-stringValue"
+    hostSecretName: "coder-certs-stringValue"
 ```
 
 Be sure to change `coder.example.com` to the domain for your Coder deployment.

--- a/guides/tls-certificates/route53.md
+++ b/guides/tls-certificates/route53.md
@@ -14,10 +14,10 @@ authority.
 > differently from earlier versions of Coder. Ensure that you're reading the
 > docs applicable to your Coder version.
 
-This guide will show you how to install cert-manager v1.4.0 and set up your
-cluster to issue Let's Encrypt certificates for your Coder installation so that
-you can enable HTTPS on your Coder deployment. It will also show you how to
-configure your Coder hostname and dev URLs.
+This guide will show you how to install cert-manager and set up your cluster to
+issue Let's Encrypt certificates for your Coder installation so that you can
+enable HTTPS on your Coder deployment. It will also show you how to configure
+your Coder hostname and dev URLs.
 
 ## Prerequisites
 
@@ -42,7 +42,7 @@ You should also:
    cert-manager:
 
    ```console
-   kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
+   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.yaml
    ```
 
 1. Check that cert-manager installs correctly by running
@@ -199,11 +199,14 @@ However, to use all of the functionality you set up in this tutorial, use the
 following command instead:
 
 ```console
+# be sure to update the `stringValue` placeholder with the
+# proper value for your devurlsHostSecretName and hostSecretName
+
 helm upgrade --install coder coder/coder --namespace coder \
   --version=<CODER_VERSION> \
   --set coderd.devurlsHost="*.coder.example.com" \
-  --set coderd.tls.devurlsHostSecretName="coder-certs" \
-  --set coderd.tls.hostSecretName="coder-certs" \
+  --set coderd.tls.devurlsHostSecretName="coder-certs-stringValue" \
+  --set coderd.tls.hostSecretName="coder-certs-stringValue" \
   --wait
 ```
 


### PR DESCRIPTION
User feedback and known condition that helm install of cert-manager is more reliable. Replaced verbiage. 