### PR TITLE
feat: change Coder description on docs homepage

### DIFF
--- a/about.md
+++ b/about.md
@@ -3,14 +3,14 @@ title: "About"
 description: "Learn about Coder, our mission, and why to choose us."
 ---
 
-Coder is a self-hosted platform for DevOps, platform, and engineering teams.
-With Coder, organizations can securely provision remote IDEs and related resources
-on their infrastructure. We call this logical group of resources a developer workspace.
+Coder is a self-hosted platform that allows organizations to securely provision
+developer workspaces (featuring remote IDEs and all related resources) for
+DevOps, platform, and software engineering teams.
 
 Coder's pre-configured workspaces allow project organization members to define
 what language version and tooling are required to provide consistency across the
-organization and enable new members to onboard and contribute. Developers focus on
-their projects and the end product, not on setup.
+organization and enable new members to onboard and contribute. Developers focus
+on their projects and the end product, not on setup.
 
 These pre-configured workspaces are the foundation of Coder's _Dev Workspaces as
 Code_ paradigm, allowing a project's language and tooling dependencies to be

--- a/about.md
+++ b/about.md
@@ -4,10 +4,9 @@ description: "Learn about Coder, our mission, and why to choose us."
 ---
 
 Coder is a self-hosted platform for DevOps, platform, and engineering teams.
-
-With Coder, developers can securely provision remote IDEs and related resources
-on their organization's infrastructure. We call this logical group of resources
-a developer workspace.
+With Coder, organizations can securely
+provision remote IDEs and related resources
+on their infrastructure. We call this logical group of resources a developer workspace.
 
 Coder's pre-configured workspaces allow project organization members to define
 what language version and tooling are required to provide consistency across the

--- a/about.md
+++ b/about.md
@@ -4,8 +4,7 @@ description: "Learn about Coder, our mission, and why to choose us."
 ---
 
 Coder is a self-hosted platform for DevOps, platform, and engineering teams.
-With Coder, organizations can securely
-provision remote IDEs and related resources
+With Coder, organizations can securely provision remote IDEs and related resources
 on their infrastructure. We call this logical group of resources a developer workspace.
 
 Coder's pre-configured workspaces allow project organization members to define

--- a/about.md
+++ b/about.md
@@ -7,7 +7,7 @@ Coder is a self-hosted platform for DevOps, platform, and engineering teams.
 
 With Coder, developers can securely provision remote IDEs and related resources
 on their organization's infrastructure. We call this logical group of resources
-a [developer workspace](workspaces/index.md).
+a developer workspace.
 
 Coder's pre-configured workspaces allow project organization members to define
 what language version and tooling are required to provide consistency across the

--- a/about.md
+++ b/about.md
@@ -3,9 +3,11 @@ title: "About"
 description: "Learn about Coder, our mission, and why to choose us."
 ---
 
-Coder moves software development to the cloud, centralizing your organizations'
-development initiatives and offering improvements in development velocity and
-enterprise security.
+Coder is a self-hosted platform for DevOps, platform, and engineering teams.
+
+With Coder, developers can securely provision remote IDEs and related resources
+on their organization's infrastructure. We call this logical group of resources
+a [developer workspace](workspaces/index.md).
 
 Coder's pre-configured workspaces allow project organization members to define
 what language version and tooling are required to provide consistency across the

--- a/index.md
+++ b/index.md
@@ -9,9 +9,8 @@ icon:
 ---
 
 Coder is a self-hosted platform for DevOps, platform, and engineering teams.
-With Coder, organizations can securely
-provision remote IDEs and related resources
-on their infrastructure. We call this logical group of resources a developer workspace.
+With Coder, organizations can securely provision remote IDEs and related resources
+on their infrastructure. We call this logical group of resources a [developer workspace](workspaces/index.md).
 
 <div class="get-started">
   <div>

--- a/index.md
+++ b/index.md
@@ -8,9 +8,9 @@ icon:
   d="M15.45,7L14,5.551V2c0-0.55-0.45-1-1-1h-1c-0.55,0-1,0.45-1,1v0.553L9,0.555C8.727,0.297,8.477,0,8,0S7.273,0.297,7,0.555  L0.55,7C0.238,7.325,0,7.562,0,8c0,0.563,0.432,1,1,1h1v6c0,0.55,0.45,1,1,1h3v-5c0-0.55,0.45-1,1-1h2c0.55,0,1,0.45,1,1v5h3  c0.55,0,1-0.45,1-1V9h1c0.568,0,1-0.437,1-1C16,7.562,15.762,7.325,15.45,7z"/></svg>'
 ---
 
-Coder is a self-hosted platform for DevOps, platform, and engineering teams.
-With Coder, organizations can securely provision remote IDEs and related resources
-on their infrastructure. We call this logical group of resources a [developer workspace](workspaces/index.md).
+Coder is a self-hosted platform that allows organizations to securely provision
+developer workspaces (featuring remote IDEs and all related resources) for
+DevOps, platform, and software engineering teams.
 
 <div class="get-started">
   <div>

--- a/index.md
+++ b/index.md
@@ -8,9 +8,9 @@ icon:
   d="M15.45,7L14,5.551V2c0-0.55-0.45-1-1-1h-1c-0.55,0-1,0.45-1,1v0.553L9,0.555C8.727,0.297,8.477,0,8,0S7.273,0.297,7,0.555  L0.55,7C0.238,7.325,0,7.562,0,8c0,0.563,0.432,1,1,1h1v6c0,0.55,0.45,1,1,1h3v-5c0-0.55,0.45-1,1-1h2c0.55,0,1,0.45,1,1v5h3  c0.55,0,1-0.45,1-1V9h1c0.568,0,1-0.437,1-1C16,7.562,15.762,7.325,15.45,7z"/></svg>'
 ---
 
-Coder moves software development to your cloud, centralizing an organization's
-development initiatives and unlocking gains in both developer velocity and
-enterprise security.
+Coder is a self-hosted platform for DevOps, platform, and engineering teams.
+With Coder, organizations can securely provision remote IDEs and related resources
+on their infrastructure. We call this logical group of resources a [developer workspace](workspaces/index.md).
 
 <div class="get-started">
   <div>

--- a/index.md
+++ b/index.md
@@ -9,8 +9,9 @@ icon:
 ---
 
 Coder is a self-hosted platform for DevOps, platform, and engineering teams.
-With Coder, organizations can securely provision remote IDEs and related resources
-on their infrastructure. We call this logical group of resources a [developer workspace](workspaces/index.md).
+With Coder, organizations can securely
+provision remote IDEs and related resources
+on their infrastructure. We call this logical group of resources a developer workspace.
 
 <div class="get-started">
   <div>


### PR DESCRIPTION
This changes the description to explain what Coder does for a more technical audience. I plan to submit future PRs which add more detail to [about.md](https://github.com/coder/docs/blob/main/about.md) to explain some new value props. 

Open to feedback!