### PR TITLE
chore: add ssh-keyscan to configure script example when git cloning

### DIFF
--- a/images/configure.md
+++ b/images/configure.md
@@ -46,11 +46,15 @@ file shows how you can clone a repo at build time:
 #!/bin/bash
 if [ ! -d "/home/coder/workspace/project" ]
 then
+ssh-keyscan -t rsa <your git provider endpoint> >> ~/.ssh/known_hosts
 git clone git://company.com/project.git /home/coder/workspace/project
 else
 echo "Project has already been cloned."
 fi
 ```
+
+> Change the git provider endpoint in the ```ssh-keyscan``` command. e.g.,
+> ```github.com``` ```bitbucket.org```  ```gitlab.com```
 
 Note that the instructions provided include `if-else` logic on whether the
 instructions should be re-run (and when) or if Coder should run the instructions


### PR DESCRIPTION
Feedback in public Slack channel was repository not cloning, based on configure script docs example. Docs were missing the ssh-keyscan command.