### PR TITLE
chore: add upload limit & IDE logs

### DIFF
--- a/workspaces/devurls.md
+++ b/workspaces/devurls.md
@@ -45,7 +45,7 @@ To access and manage a dev URL, you can click:
 - The **Edit URL** action to edit the dev URL
 - The **Delete URL** action to delete the dev URL
 
-> Coder's default dev URL upload limit is 1MB
+> Coder's dev URL upload limit is **1 MB**.
 
 ![Dev URLs List](../assets/workspaces/create-devurl.png)
 

--- a/workspaces/devurls.md
+++ b/workspaces/devurls.md
@@ -45,6 +45,8 @@ To access and manage a dev URL, you can click:
 - The **Edit URL** action to edit the dev URL
 - The **Delete URL** action to delete the dev URL
 
+> Coder's default dev URL upload limit is 1MB
+
 ![Dev URLs List](../assets/workspaces/create-devurl.png)
 
 ### Direct access

--- a/workspaces/editors.md
+++ b/workspaces/editors.md
@@ -393,3 +393,10 @@ RStudio:
    > All RStudio data is stored in the home directory associated with the user
    > you sign in as, since this ensures that your data is saved if Coder shuts
    > down or rebuilds your environment.
+
+## Logging
+
+You can find your IDE logs in the following places:
+
+- Code-server: `~/.local/share/code-server/logs/`
+- JetBrains IDEs: `.cache/JetBrains/<JetBrains-IDE>/log/<IDE>.log`

--- a/workspaces/editors.md
+++ b/workspaces/editors.md
@@ -398,5 +398,5 @@ RStudio:
 
 You can find your IDE logs in the following places:
 
-- Code-server: `~/.local/share/code-server/logs/`
-- JetBrains IDEs: `.cache/JetBrains/<JetBrains-IDE>/log/<IDE>.log`
+- For code-server: `~/.local/share/code-server/logs/`
+- For JetBrains IDEs: `.cache/JetBrains/<JetBrains-IDE>/log/<IDE>.log`


### PR DESCRIPTION
documents Coder's default upload limit of 1MB & logs for code-server & JetBrains IDEs