### PR TITLE
fix: google issuer

### DIFF
--- a/guides/admin/oidc-google.md
+++ b/guides/admin/oidc-google.md
@@ -64,7 +64,7 @@ Now that you've registered an app, you can provide the relevant **Client ID**,
 
 1. Provide the **Client ID** and **Client Secret** supplied by Google.
 
-1. For the **Issuer**, provide `accounts.google.com`.
+1. For the **Issuer**, provide `https://accounts.google.com`.
 
 1. For **Additional Scopes**, you can leave this value blank.
 


### PR DESCRIPTION
fixes the google auth issuer field. it throws an error when no protocol is specified.