### PR TITLE
chore: projector version update

### DIFF
--- a/changelog/1.29.0.md
+++ b/changelog/1.29.0.md
@@ -11,6 +11,7 @@ There are no breaking changes in 1.29.0.
 
 - web: added admin login form that appears when OIDC login is enabled and
   built-in authentication is disabled.
+- web: upgraded JetBrains Projector to version 1.6.0.
 - C4D: added support for SSH to Docker workspace providers.
 - C4D: added support for access URLs other than `localhost`.
 - cli: added ability to


### PR DESCRIPTION
adds a note to our changelog regarding upgrading Projector to version `1.6.0`