### PR TITLE
feat: NFS file share mounting guide

### DIFF
--- a/changelog/1.29.0.md
+++ b/changelog/1.29.0.md
@@ -27,6 +27,7 @@ There are no breaking changes in 1.29.0.
 
 ### Bug fixes 🐛
 
+- web: fixed an issue with RStudio login redirects
 - web: fixed issue where usernames in dev URLs were case-sensitive.
 - web: fixed issue where resource quota changes were audit logged incorrectly.
 - web: fixed issue where deleting a workspace caused a “Failed to fetch

--- a/changelog/1.29.0.md
+++ b/changelog/1.29.0.md
@@ -27,7 +27,7 @@ There are no breaking changes in 1.29.0.
 
 ### Bug fixes 🐛
 
-- web: fixed an issue with RStudio login redirects
+- web: fixed issue with RStudio login redirects.
 - web: fixed issue where usernames in dev URLs were case-sensitive.
 - web: fixed issue where resource quota changes were audit logged incorrectly.
 - web: fixed issue where deleting a workspace caused a “Failed to fetch

--- a/guides/admin/nfs.md
+++ b/guides/admin/nfs.md
@@ -1,0 +1,67 @@
+---
+title: NFS File Mounting
+description: Learn how to mount NFS file shares onto Coder workspaces
+---
+
+This guide will walk you through how to configure and mount an NFS file share to
+a Coder workspace. The NFS file share will be a separate mount from the user's
+persistent volume, represented as `/home/<user>` in the workspace.
+
+## Requirements
+
+To mount an NFS file share, you must use a Container-based Virtual Machine (CVM)
+workspace with a FUSE device attached. You can enable both of these features in
+the Admin panel by navigating to **Manage** > **Admin** > **Infrastructure** >
+**Workspace container runtime**.
+[Please review the CVM infrastructure requirements prior to enabling](https://coder.com/docs/coder/latest/admin/workspace-management/cvms).
+
+In your Coder workspace, you must install either `nfs-utils` or `nfs-common`
+installed. The server must have either `nfs-utils` or `nfs-kernel-server`
+installed.
+
+Ensure no firewalls block the client connections. By default, the NFS daemon is
+configured to run on a static port of `2049`.
+
+## Server steps
+
+1. Create an NFS mount on the server for clients to access:
+
+    ```console
+    export NFS_MNT_PATH=/mnt/nfs_share
+    # Create directory to shaare
+    sudo mkdir -p $NFS_MNT_PATH
+    # Assign UID & GIDs access
+    sudo chown -R uid:gid $NFS_MNT_PATH
+    sudo chmod 777 $NFS_MNT_PATH
+    ```
+
+1. Grant clients access by updating the `/etc/exports` file. This controls which
+   directories are shared with remote clients.
+   [See here for more information on the configuration options](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/5/html/deployment_guide/s1-nfs-server-config-exports).
+
+    ```console
+    # Provides read/write access to clients accessing the NFS from any IP address.
+    /mnt/nfs_share  *(rw,sync,no_subtree_check)
+    ```
+
+1. Export the NFS file share directory. This must be done every time
+   `/etc/exports` is changed.
+
+   ```console
+   sudo exportfs -a
+   sudo systemctl restart <nfs-package>
+   ```
+
+## Client steps (Coder workspace)
+
+1. Create a directory where the NFS mount will reside:
+
+    ```console
+    sudo mkdir -p /mnt/nfs_clientshare
+    ```
+
+1. Mount the NFS file share from the server into your workspace:
+
+    ```console
+    sudo mount <server-IP>:/mnt/nfs_share /mnt/nfs_clientshare
+    ```

--- a/guides/admin/nfs.md
+++ b/guides/admin/nfs.md
@@ -1,67 +1,70 @@
 ---
-title: NFS File Mounting
-description: Learn how to mount NFS file shares onto Coder workspaces
+title: NFS file mounting
+description: Learn how to mount NFS file shares onto Coder workspaces.
 ---
 
-This guide will walk you through how to configure and mount an NFS file share to
-a Coder workspace. The NFS file share will be a separate mount from the user's
-persistent volume, represented as `/home/<user>` in the workspace.
+This guide will walk you through configuring and mounting an NFS file share to a
+Coder workspace. The NFS file share will be separate from the user's persistent
+volume (represented as `/home/<user>` in the workspace).
 
 ## Requirements
 
-To mount an NFS file share, you must use a Container-based Virtual Machine (CVM)
+To mount an NFS file share, you must use a container-based virtual machine (CVM)
 workspace with a FUSE device attached. You can enable both of these features in
-the Admin panel by navigating to **Manage** > **Admin** > **Infrastructure** >
+the admin panel by navigating to **Manage** > **Admin** > **Infrastructure** >
 **Workspace container runtime**.
-[Please review the CVM infrastructure requirements prior to enabling](https://coder.com/docs/coder/latest/admin/workspace-management/cvms).
 
-In your Coder workspace, you must install either `nfs-utils` or `nfs-common`
-installed. The server must have either `nfs-utils` or `nfs-kernel-server`
-installed.
+> Please review
+> [the CVM infrastructure requirements before enabling](https://coder.com/docs/coder/latest/admin/workspace-management/cvms)
+> CVMs and FUSE devices.
 
-Ensure no firewalls block the client connections. By default, the NFS daemon is
-configured to run on a static port of `2049`.
+The Coder workspace must have either `nfs-utils` or `nfs-common` installed.
 
-## Server steps
+The server must have either `nfs-utils` or `nfs-kernel-server` installed.
 
-1. Create an NFS mount on the server for clients to access:
+Ensure that no firewalls are blocking the client connections. By default, the
+NFS daemon is configured to run on a static port of `2049`.
 
-    ```console
-    export NFS_MNT_PATH=/mnt/nfs_share
-    # Create directory to shaare
-    sudo mkdir -p $NFS_MNT_PATH
-    # Assign UID & GIDs access
-    sudo chown -R uid:gid $NFS_MNT_PATH
-    sudo chmod 777 $NFS_MNT_PATH
-    ```
+## Server configuration steps
 
-1. Grant clients access by updating the `/etc/exports` file. This controls which
-   directories are shared with remote clients.
-   [See here for more information on the configuration options](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/5/html/deployment_guide/s1-nfs-server-config-exports).
+1. Create an NFS mount on the server for the clients to access:
 
-    ```console
-    # Provides read/write access to clients accessing the NFS from any IP address.
-    /mnt/nfs_share  *(rw,sync,no_subtree_check)
-    ```
+   ```console
+   export NFS_MNT_PATH=/mnt/nfs_share
+   # Create directory to shaare
+   sudo mkdir -p $NFS_MNT_PATH
+   # Assign UID & GIDs access
+   sudo chown -R uid:gid $NFS_MNT_PATH
+   sudo chmod 777 $NFS_MNT_PATH
+   ```
 
-1. Export the NFS file share directory. This must be done every time
-   `/etc/exports` is changed.
+1. Grant access to the clients by updating the `/etc/exports` file, which
+   controls the directories shared with remote clients. See
+   [Red Hat's docs for more information about the configuration options](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/5/html/deployment_guide/s1-nfs-server-config-exports).
+
+   ```console
+   # Provides read/write access to clients accessing the NFS from any IP address.
+   /mnt/nfs_share  *(rw,sync,no_subtree_check)
+   ```
+
+1. Export the NFS file share directory. You must do this every time you change
+   `/etc/exports`.
 
    ```console
    sudo exportfs -a
    sudo systemctl restart <nfs-package>
    ```
 
-## Client steps (Coder workspace)
+## Client (Coder workspace) configuration steps
 
 1. Create a directory where the NFS mount will reside:
 
-    ```console
-    sudo mkdir -p /mnt/nfs_clientshare
-    ```
+   ```console
+   sudo mkdir -p /mnt/nfs_clientshare
+   ```
 
 1. Mount the NFS file share from the server into your workspace:
 
-    ```console
-    sudo mount <server-IP>:/mnt/nfs_share /mnt/nfs_clientshare
-    ```
+   ```console
+   sudo mount <server-IP>:/mnt/nfs_share /mnt/nfs_clientshare
+   ```


### PR DESCRIPTION
includes steps for mounting an NFS file share from a server into a Coder workspace. note that this requires CVMs with a FUSE device attached.

also includes a minor addition to the changelog (an RStudio bug fix).