### PR TITLE
chore: add 1.29.2 changelog to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -563,6 +563,9 @@
           "path": "./changelog/1.29.0.md",
           "children": [
             {
+              "path": "./changelog/1.29.2.md"
+            },
+            {
               "path": "./changelog/1.29.1.md"
             }
           ]


### PR DESCRIPTION
re-adds the changelog to manifest, which was removed in the initial reversion