### PR TITLE
add: nfs manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -416,10 +416,10 @@
               "path": "./guides/admin/image-tag-names.md"
             },
             {
-              "path": "./guides/admin/nfs.md"
+              "path": "./guides/admin/logging.md"
             },
             {
-              "path": "./guides/admin/logging.md"
+              "path": "./guides/admin/nfs.md"
             },
             {
               "path": "./guides/admin/oidc-azuread.md"

--- a/manifest.json
+++ b/manifest.json
@@ -416,6 +416,9 @@
               "path": "./guides/admin/image-tag-names.md"
             },
             {
+              "path": "./guides/admin/nfs.md"
+            },
+            {
               "path": "./guides/admin/logging.md"
             },
             {


### PR DESCRIPTION
adds the manifest for the NFS guide, which I forgot to include in #938 🤦🏼 