### PR TITLE
fix: rsync & mutagen directories

### DIFF
--- a/cli/file-sync.md
+++ b/cli/file-sync.md
@@ -68,7 +68,7 @@ changes.
    Name     ImageTag    CPUCores    MemoryGB    DiskGB    GPUs    Updating    Status
    yourName latest      4           4           30        0       false       ON
    test     latest      1           1           10        0       false       OFF
-   $ mutagen sync create . coder.env-name:~/project
+   $ mutagen sync create ~/project coder.env-name:~/project
    Created session sync_dLg9zfqynqVa9aj2V36Fr4OCMz1AHzTKzNGFYYkqfAI
    ```
 

--- a/workspaces/ssh.md
+++ b/workspaces/ssh.md
@@ -74,5 +74,5 @@ example, the following shows how you can transfer your home directory to your
 workspace:
 
 ```console
-rsync -e "coder ssh" -a --progress ~/. my-env:~
+rsync -e "coder ssh" -a --progress ~/project user@coder.<workspace-name>:~/project
 ```


### PR DESCRIPTION
updates our `mutagen` & `rsync` example commands to sync a specific directory instead of the entire current directory.