### PR TITLE
add: cert injection to 1.30 changelog

### DIFF
--- a/changelog/1.30.0.md
+++ b/changelog/1.30.0.md
@@ -33,6 +33,7 @@ description: "Released on 04/27/2022"
   [controls the maximum number of workspaces allowed to each user](../admin/workspace-management/limits.md).
 - infra: improved Bitbucket server account linking error messages to help debug
   integration issues.
+- infra: added certificate injection to self-contained builds.
 - infra: updated Coder so that
   [self-contained builds](../admin/workspace-management/self-contained-builds.md)
   are now the default.


### PR DESCRIPTION
adds cert-injection to `1.30` changelog for self-contained builds. implemented by @Emyrk 