### PR TITLE
chore: Change openshift example to use userdel/useradd instead of usermod

### DIFF
--- a/setup/kubernetes/openshift.md
+++ b/setup/kubernetes/openshift.md
@@ -161,7 +161,7 @@ spec:
       USER root 
 
       # As root, change the coder user id
-      RUN usermod --uid=1000670000 coder
+      RUN userdel coder && useradd -l -u 1000670000 coder && chown coder:coder /home/coder
 
       # Go back to the user 'coder'
       USER coder


### PR DESCRIPTION
When using usermod (or useradd without -l), a sparse file is created
for lastlog/faillog.  The extents of the file scale with the UID, and
Docker does not see the file as sparse, so it will try to generate a
huge image without this patch.

(See https://github.com/moby/moby/issues/5419 for details)

Signed-off-by: Burt Holzman <burt@fnal.gov>