### PR TITLE
add: selinux note for CVMs

### DIFF
--- a/admin/workspace-management/cvms/cluster-setup.md
+++ b/admin/workspace-management/cvms/cluster-setup.md
@@ -53,7 +53,7 @@ and updating your `eksctl` config spec.
 
    nodeGroups:
      - name: coder-node-group
-       amiFamily: Ubuntu2004
+       amiFamily: Ubuntu2004 # AmazonLinux2 is also a supported option
        ami: <your Ubuntu 20.04 AMI ID>
    ```
 

--- a/admin/workspace-management/cvms/index.md
+++ b/admin/workspace-management/cvms/index.md
@@ -69,7 +69,7 @@ isolation between the user's workspace container and its outer, supervising
 container is what provides
 [strong isolation](https://github.com/nestybox/sysbox/blob/master/docs/user-guide/security.md).
 
-> Sysbox does not yet support running on systems with SELinux enabled.
+> Sysbox is not yet support on systems with SELinux enabled.
 
 ## Known issues
 

--- a/admin/workspace-management/cvms/index.md
+++ b/admin/workspace-management/cvms/index.md
@@ -69,7 +69,7 @@ isolation between the user's workspace container and its outer, supervising
 container is what provides
 [strong isolation](https://github.com/nestybox/sysbox/blob/master/docs/user-guide/security.md).
 
-> Sysbox is not yet support on systems with SELinux enabled.
+> Sysbox is not yet supported on systems with SELinux enabled.
 
 ## Known issues
 

--- a/admin/workspace-management/cvms/index.md
+++ b/admin/workspace-management/cvms/index.md
@@ -69,6 +69,8 @@ isolation between the user's workspace container and its outer, supervising
 container is what provides
 [strong isolation](https://github.com/nestybox/sysbox/blob/master/docs/user-guide/security.md).
 
+> Sysbox does not yet support running on systems with SELinux enabled.
+
 ## Known issues
 
 - NVIDIA GPUs can be added to CVMs on bare metal clusters only. This feature is

--- a/setup/kubernetes/aws.md
+++ b/setup/kubernetes/aws.md
@@ -179,7 +179,7 @@ as a workspace deployment option, you'll need to
 
    managedNodeGroups:
      - name: coder-node-group
-       amiFamily: Ubuntu2004 # AmazonLinux2 is also an option
+       amiFamily: Ubuntu2004 # AmazonLinux2 is also a supported option
        # Custom EKS-compatible AMIs can be used instead of amiFamily
        # ami: <your Ubuntu 20.04 AMI ID>
        instanceType: <instance-type>


### PR DESCRIPTION
adds note regarding selinux limitation and includes AL2 support on the cluster setup page.