### PR TITLE
chore: remove references to hosted beta

### DIFF
--- a/admin/workspace-management/cvms/index.md
+++ b/admin/workspace-management/cvms/index.md
@@ -73,9 +73,9 @@ container is what provides
 
 ## Known issues
 
-- Do not add configuration files like bash scripts to `/tmp` in CVMs since they will not
-  be available once the CVM workspace is built. Consider `/coder` which already
-  holds the `'configure` script.
+- Do not add configuration files like bash scripts to `/tmp` in CVMs since they
+  will not be available once the CVM workspace is built. Consider `/coder` which
+  already holds the `'configure` script.
 
 - NVIDIA GPUs can be added to CVMs on bare metal clusters only. This feature is
   not supported on Google Kubernetes Engine or other cloud providers at this

--- a/admin/workspace-management/cvms/index.md
+++ b/admin/workspace-management/cvms/index.md
@@ -73,6 +73,10 @@ container is what provides
 
 ## Known issues
 
+- Do not add configuration files like bash scripts to `/tmp` in CVMs since they will not
+  be available once the CVM workspace is built. Consider `/coder` which already
+  holds the `'configure` script.
+
 - NVIDIA GPUs can be added to CVMs on bare metal clusters only. This feature is
   not supported on Google Kubernetes Engine or other cloud providers at this
   time.

--- a/setup/kubernetes/aws.md
+++ b/setup/kubernetes/aws.md
@@ -249,9 +249,8 @@ For more information, see:
 
 ## Next steps
 
-If you have already installed Coder or are using our hosted beta, you can add
-this cluster as a
-[workspace provider](../../admin/workspace-providers/deployment/index.md).
+If you have already installed Coder, you can add this cluster as a [workspace
+provider](../../admin/workspace-providers/deployment/index.md).
 
 To access Coder through a secure domain, review our guides on configuring and
 using [TLS certificates](../../guides/tls-certificates/index.md).

--- a/setup/kubernetes/azure.md
+++ b/setup/kubernetes/azure.md
@@ -137,9 +137,8 @@ For more information, see:
 
 ## Next steps
 
-If you have already installed Coder or are using our hosted beta, you can add
-this cluster as a
-[workspace provider](../../admin/workspace-providers/deployment/index.md).
+If you have already installed Coder, you can add this cluster as a [workspace
+provider](../../admin/workspace-providers/deployment/index.md).
 
 To access Coder through a secure domain, review our guides on configuring and
 using [TLS certificates](../../guides/tls-certificates/index.md).

--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -153,9 +153,8 @@ For more information, see:
 
 ## Next steps
 
-If you have already installed Coder or are using our hosted beta, you can add
-this cluster as a
-[workspace provider](../../admin/workspace-providers/deployment/index.md).
+If you have already installed Coder, you can add this cluster as a [workspace
+provider](../../admin/workspace-providers/deployment/index.md).
 
 To access Coder through a secure domain, review our guides on configuring and
 using [TLS certificates](../../guides/tls-certificates/index.md).

--- a/setup/kubernetes/k3s.md
+++ b/setup/kubernetes/k3s.md
@@ -116,9 +116,8 @@ cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
 
 ## Next steps
 
-If you have already installed Coder or are using our hosted beta, you can add
-this cluster as a
-[workspace provider](../../admin/workspace-providers/deployment/index.md).
+If you have already installed Coder, you can add this cluster as a [workspace
+provider](../../admin/workspace-providers/deployment/index.md).
 
 To access Coder through a secure domain, review our guides on configuring and
 using [TLS certificates](../../guides/tls-certificates/index.md).


### PR DESCRIPTION
v1 docs still reference the hosted trial in the Kubernetes install docs. I removed those references.