### PR TITLE
chore: added dotfiles special character fix to 1.32.1 changelog

### DIFF
--- a/changelog/1.32.1.md
+++ b/changelog/1.32.1.md
@@ -15,7 +15,7 @@ There are no features in 1.32.1.
 
 - infra: fixed an issue which caused multiple audit log events to be created for
   a single auto-off event.
-- web: fixed an issue with special characters like `~` causing dotfiles URLs to not save.
+- web: fixed an issue with special characters causing dotfiles URLs to not save.
 
 ### Security updates 🔐
 

--- a/changelog/1.32.1.md
+++ b/changelog/1.32.1.md
@@ -15,6 +15,7 @@ There are no features in 1.32.1.
 
 - infra: fixed an issue which caused multiple audit log events to be created for
   a single auto-off event.
+- web: fixed an issue with special characters like `~` causing dotfiles URLs to not save.
 
 ### Security updates 🔐
 


### PR DESCRIPTION
This fix was in 1.32.1 but not shown in the changelog.