### PR TITLE
chore: add release notes for 1.32.2, 1.31.2, 1.30.4

### DIFF
--- a/changelog/1.30.4.md
+++ b/changelog/1.30.4.md
@@ -1,0 +1,25 @@
+---
+title: "1.30.4"
+description: "Released on 07/20/2022"
+---
+
+### Breaking changes ❗
+
+- infra: the "Getting default user from image" build step now spawns a container
+  that consumes 100m CPU and 250mb of memory. Previously these were unset, which
+  can cause issues with some Kubernetes variants.
+
+### Features ✨
+
+There are no new features in 1.30.4.
+
+### Bug fixes 🐛
+
+- web: fixed an issue where users that never interacted with workspaces would
+  not be counted as an active user.
+- web: fixed an issue preventing the metrics UI from displaying the graph.
+- infra: fixed a memory leak triggered by DevURL requests.
+
+### Security updates 🔐
+
+There are no security updates in 1.30.4.

--- a/changelog/1.31.2.md
+++ b/changelog/1.31.2.md
@@ -1,0 +1,25 @@
+---
+title: "1.31.2"
+description: "Released on 07/20/2022"
+---
+
+### Breaking changes ❗
+
+- infra: the "Getting default user from image" build step now spawns a container
+  that consumes 100m CPU and 250mb of memory. Previously these were unset, which
+  can cause issues with some Kubernetes variants.
+
+### Features ✨
+
+- infra: updated code-server to 4.5.1.
+
+### Bug fixes 🐛
+
+- web: fixed an issue where users that never interacted with workspaces would
+  not be counted as an active user.
+- web: fixed an issue preventing the metrics UI from displaying the graph.
+- infra: fixed a memory leak triggered by DevURL requests.
+
+### Security updates 🔐
+
+There are no security updates in 1.31.2.

--- a/changelog/1.31.2.md
+++ b/changelog/1.31.2.md
@@ -11,7 +11,7 @@ description: "Released on 07/20/2022"
 
 ### Features ✨
 
-- infra: updated code-server to 4.5.1.
+There are no new features in 1.31.2.
 
 ### Bug fixes 🐛
 

--- a/changelog/1.32.2.md
+++ b/changelog/1.32.2.md
@@ -11,6 +11,7 @@ description: "Released on 07/20/2022"
 
 ### Features ✨
 
+- infra: updated code-server to 4.5.1.
 - cli: added usernames to the workspaces list command.
 
 ### Bug fixes 🐛

--- a/changelog/1.32.2.md
+++ b/changelog/1.32.2.md
@@ -1,0 +1,30 @@
+---
+title: "1.32.2"
+description: "Released on 07/20/2022"
+---
+
+### Breaking changes ❗
+
+- infra: the "Getting default user from image" build step now spawns a container
+  that consumes 100m CPU and 250mb of memory. Previously these were unset, which
+  can cause issues with some Kubernetes variants.
+
+### Features ✨
+
+- cli: added usernames to the workspaces list command.
+
+### Bug fixes 🐛
+
+- infra: fixed an issue where P2P connections used the wrong access URL for some
+  workspace providers.
+- infra: fixed an issue where site admins lacked permissions to query user
+  DevURLs.
+- web: fixed an issue where users that never interacted with workspaces would
+  not be counted as an active user.
+- web: fixed an issue preventing the metrics UI from displaying the graph.
+- infra: fixed a memory leak triggered by DevURL requests.
+- infra: fixed an issue which made workspaces unable to be built in Rancher.
+
+### Security updates 🔐
+
+There are no security updates in 1.32.2.

--- a/manifest.json
+++ b/manifest.json
@@ -567,6 +567,9 @@
           "path": "./changelog/1.32.0.md",
           "children": [
             {
+              "path": "./changelog/1.32.2.md"
+            },
+            {
               "path": "./changelog/1.32.1.md"
             }
           ]
@@ -575,6 +578,9 @@
           "path": "./changelog/1.31.0.md",
           "children": [
             {
+              "path": "./changelog/1.31.2.md"
+            },
+            {
               "path": "./changelog/1.31.1.md"
             }
           ]
@@ -582,6 +588,9 @@
         {
           "path": "./changelog/1.30.0.md",
           "children": [
+            {
+              "path": "./changelog/1.30.4.md"
+            },
             {
               "path": "./changelog/1.30.3.md"
             },


### PR DESCRIPTION
## Changelog Run History (`cdr/m/scripts/clog/generate-clog.sh`)

- **yyyy-mm-dd**
  - Using Previous Object: `<some-ref>`
  - Using Latest Object: `<some-ref>`

## Release Checklist

- [x] All Feature documentation merged
- [x] Changelog completed
- [x] Technical Engineer Review
- [x] Documentation Owner Review
- [x] Release Manager Review
- [x] Commit cleaned up and co-authored
