### PR TITLE
chore: docs for Azure and IP address planning

### DIFF
--- a/setup/kubernetes/azure.md
+++ b/setup/kubernetes/azure.md
@@ -31,6 +31,20 @@ for more information.
 > [container-based virtual machines (CVMs)](../../workspaces/cvms.md) unless
 > you're running Coder in a bare-metal Kubernetes environment.
 
+## Pod IP Addresses
+
+By default, AKS clusters use
+[kubenet](https://docs.microsoft.com/en-us/azure/aks/concepts-network#kubenet-basic-networking),
+and a virtual network and subnet are created for you. With kubenet, nodes get an
+IP address from a virtual network subnet. Network address translation (NAT) is
+then configured on the nodes, and pods receive an IP address "hidden" behind the
+node IP. This approach reduces the number of IP addresses that you need to
+reserve in your network space for pods to use.
+
+Alternatively with [Azure Container Networking Interface
+(CNI)](https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni#plan-ip-addressing-for-your-cluster),
+every pod gets an IP address from the subnet and can be accessed directly.
+
 ## Step 1: Create the resource group
 
 To make subsequent steps easier, start by creating environment variables for the


### PR DESCRIPTION
PR to:
1. Update the Kubernetes Azure install docs to explain the options for allocating IP addresses for Coder pods