### PR TITLE
add: JetBrains IDE/Projector incompatabilities

### DIFF
--- a/changelog/1.30.0.md
+++ b/changelog/1.30.0.md
@@ -90,3 +90,5 @@ description: "Released on 04/27/2022"
   `ubuntu:latest`) will fail to build on new Coder deployments with
   self-contained workspace builds enabled. The workaround is to use a base image
   with `curl` available (e.g., `codercom/enterprise-base:ubuntu`).
+- web: JetBrains IDEs versions 2022.2 or later are not compatible with the
+  installed Projector version in this release.

--- a/changelog/1.30.1.md
+++ b/changelog/1.30.1.md
@@ -20,3 +20,8 @@ There are no breaking changes in 1.30.1.
 ### Security updates 🔐
 
 There are no security updates in 1.30.1.
+
+### Known issues 🔧
+
+- web: JetBrains IDEs versions 2022.2 or later are not compatible with the
+  installed Projector version in this release.

--- a/changelog/1.30.2.md
+++ b/changelog/1.30.2.md
@@ -20,3 +20,8 @@ There are no new features in 1.30.2.
 ### Security updates 🔐
 
 There are no security updates in 1.30.2.
+
+### Known issues 🔧
+
+- web: JetBrains IDEs versions 2022.2 or later are not compatible with the
+  installed Projector version in this release.

--- a/changelog/1.30.3.md
+++ b/changelog/1.30.3.md
@@ -19,3 +19,8 @@ There are no breaking changes in 1.30.3.
 ### Security updates 🔐
 
 There are no security updates in 1.30.3.
+
+### Known issues 🔧
+
+- web: JetBrains IDEs versions 2022.2 or later are not compatible with the
+  installed Projector version in this release.

--- a/changelog/1.30.4.md
+++ b/changelog/1.30.4.md
@@ -23,3 +23,8 @@ There are no new features in 1.30.4.
 ### Security updates 🔐
 
 There are no security updates in 1.30.4.
+
+### Known issues 🔧
+
+- web: JetBrains IDEs versions 2022.2 or later are not compatible with the
+  installed Projector version in this release.

--- a/changelog/1.31.0.md
+++ b/changelog/1.31.0.md
@@ -50,3 +50,5 @@ There are no security updates in 1.31.0.
   upload their license when prompted.
 - web: by default, Coder workspace builds are self-contained; as such, images
   that do _not_ contain `curl` will result in the workspace failing to build.
+- web: JetBrains IDEs versions 2022.2 or later are not compatible with the
+  installed Projector version in this release.

--- a/changelog/1.31.1.md
+++ b/changelog/1.31.1.md
@@ -18,3 +18,8 @@ There are no breaking changes in 1.31.1.
 ### Security updates 🔐
 
 There are no security updates in 1.31.1.
+
+### Known issues 🔧
+
+- web: JetBrains IDEs versions 2022.2 or later are not compatible with the
+  installed Projector version in this release.

--- a/changelog/1.31.2.md
+++ b/changelog/1.31.2.md
@@ -23,3 +23,8 @@ There are no new features in 1.31.2.
 ### Security updates 🔐
 
 There are no security updates in 1.31.2.
+
+### Known issues 🔧
+
+- web: JetBrains IDEs versions 2022.2 or later are not compatible with the
+  installed Projector version in this release.

--- a/changelog/1.32.0.md
+++ b/changelog/1.32.0.md
@@ -57,3 +57,5 @@ There are no breaking changes in 1.32.0.
   upload their license when prompted.
 - web: by default, Coder workspace builds are self-contained; as such, images
   that do _not_ contain `curl` will result in the workspace failing to build.
+- web: JetBrains IDEs versions 2022.2 or later are not compatible with the
+  installed Projector version in this release.

--- a/changelog/1.32.1.md
+++ b/changelog/1.32.1.md
@@ -20,3 +20,8 @@ There are no features in 1.32.1.
 ### Security updates 🔐
 
 There are no security updates in 1.32.1.
+
+### Known issues 🔧
+
+- web: JetBrains IDEs versions 2022.2 or later are not compatible with the
+  installed Projector version in this release.

--- a/changelog/1.32.2.md
+++ b/changelog/1.32.2.md
@@ -29,3 +29,8 @@ description: "Released on 07/20/2022"
 ### Security updates 🔐
 
 There are no security updates in 1.32.2.
+
+### Known issues 🔧
+
+- web: JetBrains IDEs versions 2022.2 or later are not compatible with the
+  installed Projector version in this release.

--- a/changelog/1.32.3.md
+++ b/changelog/1.32.3.md
@@ -20,3 +20,8 @@ There are no breaking changes in 1.32.3.
 ### Security updates 🔐
 
 There are no security updates in 1.32.3.
+
+### Known issues 🔧
+
+- web: JetBrains IDEs versions 2022.2 or later are not compatible with the
+  installed Projector version in this release.

--- a/changelog/1.33.0.md
+++ b/changelog/1.33.0.md
@@ -38,3 +38,8 @@ description: "Released on 07/27/2022"
 ### Security updates 🔐
 
 There are no security updates in 1.33.0.
+
+### Known issues 🔧
+
+- web: JetBrains IDEs versions 2022.2 or later are not compatible with the
+  installed Projector version in this release.

--- a/cli/file-sync.md
+++ b/cli/file-sync.md
@@ -68,9 +68,12 @@ changes.
    Name     ImageTag    CPUCores    MemoryGB    DiskGB    GPUs    Updating    Status
    yourName latest      4           4           30        0       false       ON
    test     latest      1           1           10        0       false       OFF
-   $ mutagen sync create ~/project coder.env-name:~/project
+   $ mutagen sync create ~/project coder.env-name:/target-dir
    Created session sync_dLg9zfqynqVa9aj2V36Fr4OCMz1AHzTKzNGFYYkqfAI
    ```
+
+> Do not include ~/ or /home in your target directory definition. Mutagen will
+> look in the home directory by default.
 
 1. Test your connection by running `mutagen sync monitor`. If you're successful,
    your project files should sync on all future changes.


### PR DESCRIPTION
makes known an issue with JetBrains IDEs version `2022.2` being incompatible with the Projector client/server versions used in Coder releases `1.33.0` & earlier.