### PR TITLE
rm: remote build deprecation notice & add troubleshooting steps

### DIFF
--- a/admin/workspace-management/self-contained-builds.md
+++ b/admin/workspace-management/self-contained-builds.md
@@ -36,11 +36,11 @@ This will result in the error below:
 stream logs from workspace: Failed to create Container-based Virtual Machine
 ```
 
-To resolve this error, you will need to copy the `coderd` TLS certificate into
+To resolve this, you will need to copy the `coderd` TLS certificate into
 your Docker image's certificate trust store. Below are examples for doing so,
 for the major distributions:
 
-### Ubuntu and Debian
+### Debian and Ubuntu derived distributions
 
 ```Dockerfile
 RUN apt-get install -y ca-certificates
@@ -48,7 +48,7 @@ COPY my-cert.pem /usr/local/share/ca-certificates/my-cert.pem
 RUN update-ca-certificates
 ```
 
-### CentOS
+### CentOS, Fedora, RedHat distributions
 
 ```Dockerfile
 RUN yum install ca-certificates && update-ca-trust force-enable

--- a/admin/workspace-management/self-contained-builds.md
+++ b/admin/workspace-management/self-contained-builds.md
@@ -15,8 +15,6 @@ Beginning with v1.30.0, the default is **self-contained workspace builds**,
 though site managers can toggle this feature off and opt for remote builds
 instead.
 
-> Coder plans to deprecate remote workspace builds in the future.
-
 To toggle self-contained workspace builds:
 
 1. Log into Coder.
@@ -29,7 +27,31 @@ To toggle self-contained workspace builds:
 > Build errors are typically more verbose for remote builds than with
 > self-contained builds.
 
-## Known issues
+## Troubleshooting
 
-At this time, Coder does not support certificate injection with self-contained
-workspace builds.
+In certain cases, your workspace may not trust the `coderd` TLS certificate.
+This will result in the error below:
+
+```console
+stream logs from workspace: Failed to create Container-based Virtual Machine
+```
+
+To resolve this error, you will need to copy the `coderd` TLS certificate into
+your Docker image's certificate trust store. Below are examples for doing so,
+for the major distributions:
+
+### Ubuntu and Debian
+
+```Dockerfile
+RUN apt-get install -y ca-certificates
+COPY my-cert.pem /usr/local/share/ca-certificates/my-cert.pem
+RUN update-ca-certificates
+```
+
+### CentOS
+
+```Dockerfile
+RUN yum install ca-certificates && update-ca-trust force-enable
+COPY my-cert.pem /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust extract
+```

--- a/admin/workspace-management/self-contained-builds.md
+++ b/admin/workspace-management/self-contained-builds.md
@@ -40,7 +40,7 @@ To resolve this, you will need to copy the `coderd` TLS certificate into
 your Docker image's certificate trust store. Below are examples for doing so,
 for the major distributions:
 
-### Debian and Ubuntu derived distributions
+### Debian and Ubuntu distributions
 
 ```Dockerfile
 RUN apt-get install -y ca-certificates


### PR DESCRIPTION
removes the `remote workspace builds` deprecation notice and adds steps to install the `coderd` TLS cert into the appropriate CA trust store for each distro.