### PR TITLE
chore: update az aks create invocation in azure setup docs

### DIFF
--- a/comparison.md
+++ b/comparison.md
@@ -77,6 +77,6 @@ support.
 > To get a free trial of Coder, please visit
 > [https://coder.com/trial](https://coder.com/trial).
 
-> Coder's trial license does not work in an air-gapped environment. If your
-> organization is interested in evaluating Coder air-gapped, please contact
-> [sales@coder.com](mailto:sales@coder.com) to discuss license requirements.
+Coder's trial license does not work in an air-gapped environment. If your
+organization is interested in evaluating Coder air-gapped, please contact
+[sales@coder.com](mailto:sales@coder.com) to discuss license requirements.

--- a/setup/kubernetes/azure.md
+++ b/setup/kubernetes/azure.md
@@ -108,9 +108,9 @@ az aks create \
   --location "$LOCATION" \
   --max-count 10 \
   --min-count 2 \
+  --node-count 2 \
   --node-vm-size Standard_B8ms \
-  --network-plugin "kubenet" \
-  --network-policy "azure"
+  --network-plugin "kubenet"
 ```
 
 > Both options include the


### PR DESCRIPTION
* Cannot set `--network-policy azure` with `--network-plugin kubenet`:
```
(NetworkPolicyAzureNotSupportedForKubenet) NetworkPolicy azure is not supported for network plugin kubenet
Code: NetworkPolicyAzureNotSupportedForKubenet
Message: NetworkPolicy azure is not supported for network plugin kubenet
Target: networkProfile.networkPolicy
```

* Must set the `--node-count` parameter equal to `--min-count` as it appears to default to 0 if unspecified.