### PR TITLE
chore: provide better path to discuss evaluating coder v1 air-gapped

### DIFF
--- a/comparison.md
+++ b/comparison.md
@@ -75,6 +75,8 @@ support.
 </table>
 
 > To get a free trial of Coder, please visit
-> [https://coder.com/trial](https://coder.com/trial). To evaluate Coder in an
-> air-gapped network during the free trial period, please <a target="_blank"
-> href="https://coder.com/contact">contact Sales</a>.
+> [https://coder.com/trial](https://coder.com/trial).
+
+> Coder's trial license does not work in an air-gapped environment. If your
+> organization is interested in evaluating Coder air-gapped, please contact
+> [sales@coder.com](mailto:sales@coder.com) to discuss license requirements.

--- a/setup/air-gapped/index.md
+++ b/setup/air-gapped/index.md
@@ -12,8 +12,9 @@ To do so, you must:
 - Push the images to your Docker registry,
 - Deploy Coder from within your air-gapped environment
 
-> Coder licenses issued as part of the trial program do not support air-gapped
-> deployments.
+> Coder's trial license does not work in an air-gapped environment. If your
+> organization is interested in evaluating Coder air-gapped, please contact
+> [sales@coder.com](mailto:sales@coder.com) to discuss license requirements.
 
 ## Dependencies
 

--- a/setup/architecture.md
+++ b/setup/architecture.md
@@ -27,7 +27,6 @@ There are two ways to deploy Coder:
    by first pulling in all of the required resources, or you can choose to
    whitelist the URLs/IP addresses needed to access Coder resources
 
-> Coder cannot be deployed in an air-gapped workspace when using the free
-> license tier. If you need to deploy an air-gapped Coder instance, please
-> [contact our sales department](mailto:sales@coder.com) to see about purchasing
-> licenses.
+> Coder's trial license does not work in an air-gapped environment. If your
+> organization is interested in evaluating Coder air-gapped, please contact
+> [sales@coder.com](mailto:sales@coder.com) to discuss license requirements.

--- a/setup/requirements.md
+++ b/setup/requirements.md
@@ -132,5 +132,6 @@ Deployments using the free trial of Coder:
 - Cannot be deployed in an air-gapped network
 - Must use Coder v1.10.0 or later
 
-The above requirements do not apply to potential customers engaged in our
-evaluation program.
+> Coder's trial license does not work in an air-gapped environment. If your
+> organization is interested in evaluating Coder air-gapped, please contact
+> [sales@coder.com](mailto:sales@coder.com) to discuss license requirements.


### PR DESCRIPTION
v1 docs, in various locations, make it sound it is impossible to evaluate Coder in an air-gapped environment. That is incorrect. Many qualified prospects, typically large organizations, must evaluate Coder in an air-gapped environment.

References are updated to direct inquiries to sales@coder.com to discuss evaluation options since a specific license file type does allow this.