### PR TITLE
chore: offline docs were not visible; added to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -188,7 +188,10 @@
           "children": [
             {
               "path": "./setup/air-gapped/infrastructure.md"
-            }
+            },
+            {
+              "path": "./setup/air-gapped/offline-docs.md"
+            }            
           ]
         },
         {


### PR DESCRIPTION
We added the doc to explain how to access and configure Offline Docs but did not make it visible. i.e., put the link in the manifest to show on the left tree under Air-Gapped.