### PR TITLE
fix: make env var a string

### DIFF
--- a/admin/git.md
+++ b/admin/git.md
@@ -123,5 +123,5 @@ When done, click **Save**.
 >   extraEnvs:
 >     [...]
 >     - name: CODERD_BITBUCKET_CONSUMER_KEY
->       value: XXX
+>       value: ""
 > ```

--- a/admin/workspace-management/limits.md
+++ b/admin/workspace-management/limits.md
@@ -12,5 +12,5 @@ so, [update your Helm chart](../../guides/admin/helm-charts.md) and set the
 coderd:
   extraEnvs:
     - name: CODER_MAX_WORKSPACES_PER_USER
-      value: 100
+      value: "100"
 ```


### PR DESCRIPTION
our docs incorrectly reference an env var as an `integer` rather than a string. the `extraEnvs` value is defined as type `string` in the [core v1 API docs](https://pkg.go.dev/k8s.io/api/core/v1#EnvVar).