### PR TITLE
fix: make jupyter binary executable

### DIFF
--- a/workspaces/editors.md
+++ b/workspaces/editors.md
@@ -364,6 +364,8 @@ RUN mv /usr/local/bin/jupyter /usr/local/bin/jupyter.py
 
 COPY jupyter /usr/local/bin/jupyter
 
+RUN chmod +x jupyter
+
 USER coder
 ```
 


### PR DESCRIPTION
this change ensures that the script to enable JupyterLab is executable by Coder upon workspace start.