### PR TITLE
Updating AWS RDS IAM Auth Documentation

### DIFF
--- a/guides/admin/awsrds.md
+++ b/guides/admin/awsrds.md
@@ -51,7 +51,7 @@ to use for database authentication.
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
                 "StringEquals": {
-                    "arn:aws:iam::111122223333:oidc-provider/oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:sub":"system:serviceaccount:<cluster>:<namespace>"
+                    "oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:sub":"system:serviceaccount:<cluster>:<namespace>"
                 }
             }
         }
@@ -65,6 +65,7 @@ to use for database authentication.
 ```sql
 CREATE USER dbuser WITH LOGIN; 
 GRANT rds_iam TO dbuser;
+GRANT CREATE ON DATABASE database TO dbuser;
 ```
 
 1. Set the following values in your Helm chart and re-deploy Coder.

--- a/guides/admin/awsrds.md
+++ b/guides/admin/awsrds.md
@@ -65,7 +65,7 @@ to use for database authentication.
 ```sql
 CREATE USER dbuser WITH LOGIN; 
 GRANT rds_iam TO dbuser;
-GRANT CREATE ON DATABASE database TO dbuser;
+GRANT CREATE ON DATABASE coder TO dbuser;
 ```
 
 1. Set the following values in your Helm chart and re-deploy Coder.


### PR DESCRIPTION
I ran into an issue recently when trying to enable this for a new RDS DB Cluster within AWS. My proposed changes are what got me to a working solution with my setup. This included updating the Trust Relationship policy condition to only use the IAM Identity Provider name instead of the full ARN. Also, I ran into a permission issue with a fresh database and my non-admin database user, so I needed to provide an extra grant command to allow the ability to create expressions as part of the initial startup.