### PR TITLE
chore: update air-gap setup to include code-marketplace, and remote SSH IDE with air-gap

### DIFF
--- a/setup/air-gapped/index.md
+++ b/setup/air-gapped/index.md
@@ -166,26 +166,8 @@ platform images are hosted in Coder's Docker Hub repo.
 ## Extensions marketplace
 
 Coder users in an air-gapped environment cannot access the public VS Code
-marketplace. However, you can point Coder to an air-gapped instance of
-[Open VSX](https://github.com/eclipse/openvsx) to serve assets to users. For
-instructions on how to do this, see
+marketplace. However, you can point Coder to an air-gapped instance of either
+[Coder's code-marketplace OSS](https://github.com/coder/code-marketplace) or
+[Open VSX](https://github.com/eclipse/openvsx) to serve VS Code extensions to
+users. For instructions on how to do either approach, see
 [Extensions](../../admin/workspace-management/extensions.md).
-
-Please review the [Open VSX deployment wiki] for more information on setting up
-your Open VSX deployment. Note that there are several components involved,
-including:
-
-- The server application, available as the
-  [openvsx-server Docker image](https://github.com/eclipse/openvsx/pkgs/container/openvsx-server)
-- A PostgreSQL instance to hold the metadata of the published extensions
-  - If you use just a database for storage, Open VSX stores everything as binary
-    data, which can increase the storage and network throughput of the database
-    considerable. As such, Open VSX recommends leveraging external storage
-    (e.g., Azure Blob Storage or Google Cloud Storage)
-- Elasticsearch, which Open VSX uses as the default search engine for search
-  queries that originate from the web UI; this is optional, since you can either
-  turn off searches or use database queries
-- GitHub OAuth for user authentication
-
-[open vsx deployment wiki]:
-  https://github.com/eclipse/openvsx/wiki/Deploying-Open-VSX

--- a/workspaces/editors.md
+++ b/workspaces/editors.md
@@ -36,7 +36,9 @@ from your local VS Code, connected to your Coder workspace for compute, etc.
 > Code's [setting](https://code.visualstudio.com/docs/getstarted/settings) with
 > `remote.SSH.allowLocalServerDownload` enabled so the extension will install
 > the VS Code Server on the client first and then copy it over to the Coder
-> workspace via SCP. [Troubleshooting hanging or failing
+> workspace via SCP.
+> 
+> For further troubleshooting steps, see [Troubleshooting hanging or failing
 > connections](https://code.visualstudio.com/docs/remote/troubleshooting#_troubleshooting-hanging-or-failing-connections)
 
 ![VS Code Remote Explorer](../assets/workspaces/vscode-remote-ssh-panel.png)

--- a/workspaces/editors.md
+++ b/workspaces/editors.md
@@ -32,6 +32,13 @@ from your local VS Code, connected to your Coder workspace for compute, etc.
 1. In VS Code's left-hand nav bar, click **Remote Explorer** and right-click on
    a workspace to connect
 
+> If Coder is deployed air-gapped (no Internet), you need to configure your VS
+> Code's [setting](https://code.visualstudio.com/docs/getstarted/settings) with
+> `remote.SSH.allowLocalServerDownload` enabled so the extension will install
+> the VS Code Server on the client first and then copy it over to the Coder
+> workspace via SCP. [Troubleshooting hanging or failing
+> connections](https://code.visualstudio.com/docs/remote/troubleshooting#_troubleshooting-hanging-or-failing-connections)
+
 ![VS Code Remote Explorer](../assets/workspaces/vscode-remote-ssh-panel.png)
 
 ## VS Code in the browser


### PR DESCRIPTION
This PR addresses:

1. Prospect feedback where local VS Code was failing to connect to a Coder workspace using the SSH Remote extension because they were deployed air-gapped. Microsoft has a documented local VS Code settings to upload the server components required versus dialing the Internet. [Article](https://code.visualstudio.com/blogs/2019/10/03/remote-ssh-tips-and-tricks#:~:text=p%0A%20%20%20%20ControlPersist%20600-,Offline%20remote%20machine,-%23)
2. Incomplete docs for air-gapped extensions marketplaces. Updated a 2nd part of the docs, in the air-gapped setup about using Coder's new OSS `code-marketplace` as an offline VS Code extensions marketplace that can be used in an air-gapped deployment.