### PR TITLE
docs: correct path to jetbrains ide bin path

### DIFF
--- a/workspaces/editors.md
+++ b/workspaces/editors.md
@@ -159,7 +159,7 @@ JetBrains IDE directory to point the default Gateway directory to the IDE
 directory. This step must be done before configuring Gateway.
 
 ```sh
-cd /opt/idea
+cd /opt/idea/bin
 ./remote-dev-server.sh registerBackendLocationForGateway
 ```
 


### PR DESCRIPTION
added `/bin` to script location where if run, points to a JetBrains IDE directory for Gateway to use.