### PR TITLE
deprecate: ec2 & docker providers

### DIFF
--- a/admin/workspace-providers/deployment/docker.md
+++ b/admin/workspace-providers/deployment/docker.md
@@ -5,8 +5,8 @@ state: alpha
 ---
 
 > This Workspace Provider type is no longer supported in Coder v1. Please use
-> our [open-source project Coder v2](https://coder.com/docs/coder-oss/latest) to
-> use a remote VM as a workspace provisioner.
+> [Coder v2](https://coder.com/docs/coder-oss/latest) to use a remote VM as a
+> workspace provisioner.
 
 This article walks you through the process of deploying a workspace provider to
 a remote VM instance using Docker.

--- a/admin/workspace-providers/deployment/docker.md
+++ b/admin/workspace-providers/deployment/docker.md
@@ -4,6 +4,10 @@ description: Learn how to deploy a workspace provider to a Docker instance.
 state: alpha
 ---
 
+> This Workspace Provider type is no longer supported in Coder v1. Please use
+> our [open-source project Coder v2](https://coder.com/docs/coder-oss/latest) to
+> use a remote VM as a workspace provisioner.
+
 This article walks you through the process of deploying a workspace provider to
 a remote VM instance using Docker.
 

--- a/admin/workspace-providers/deployment/ec2.md
+++ b/admin/workspace-providers/deployment/ec2.md
@@ -5,8 +5,8 @@ state: alpha
 ---
 
 > This Workspace Provider type is no longer supported in Coder v1. Please use
-> our [open-source project Coder v2](https://coder.com/docs/coder-oss/latest) to
-> provision EC2 instances as workspaces.
+> [Coder v2](https://coder.com/docs/coder-oss/latest) to provision EC2 instances
+> as workspaces.
 
 This article walks you through the process of deploying a workspace provider to
 an EC2 instance.

--- a/admin/workspace-providers/deployment/ec2.md
+++ b/admin/workspace-providers/deployment/ec2.md
@@ -4,6 +4,10 @@ description: Learn how to deploy a workspace provider to an EC2 instance.
 state: alpha
 ---
 
+> This Workspace Provider type is no longer supported in Coder v1. Please use
+> our [open-source project Coder v2](https://coder.com/docs/coder-oss/latest) to
+> provision EC2 instances as workspaces.
+
 This article walks you through the process of deploying a workspace provider to
 an EC2 instance.
 


### PR DESCRIPTION
notes that the ec2 & docker providers are no longer supported. points folks to use v2 for the respective use-cases.