### PR TITLE
Added 1.36.1 changelog

### DIFF
--- a/changelog/1.36.1.md
+++ b/changelog/1.36.1.md
@@ -14,7 +14,7 @@ There are no new features in 1.36.1
 ### Bug fixes 🐛
 
 - infra: Fixed an issue where Coder services would incorrectly leave out client
-  TLS credentials when communicating with Gitlab
+  TLS credentials when communicating with GitLab
 
 ### Security updates 🔐
 

--- a/changelog/1.36.1.md
+++ b/changelog/1.36.1.md
@@ -1,0 +1,22 @@
+---
+title: "1.36.1"
+description: "Released on 11/14/2022"
+---
+
+### Breaking changes ❗
+
+There are no breaking changes in 1.36.1
+
+### Features ✨
+
+There are no new features in 1.36.1
+
+### Bug fixes 🐛
+
+- infra: Fixed an issue where Coder services would incorrectly leave out client
+  TLS credentials when communicating with Gitlab
+
+### Security updates 🔐
+
+- infra: Fixed an issued where ordinary users could obtain admin-level 
+  credentials from the Coder API.

--- a/changelog/1.36.1.md
+++ b/changelog/1.36.1.md
@@ -18,5 +18,5 @@ There are no new features in 1.36.1
 
 ### Security updates 🔐
 
-- infra: Fixed an issued where ordinary users could obtain admin-level 
+- infra: Fixed an issued where ordinary users could obtain admin-level
   credentials from the Coder API.

--- a/manifest.json
+++ b/manifest.json
@@ -588,7 +588,12 @@
       "icon_path": "./assets/images/icons/paper.svg",
       "children": [
         {
-          "path": "./changelog/1.36.0.md"
+          "path": "./changelog/1.36.0.md",
+          "children": [
+            {
+              "path": "./changelog/1.35.1.md"
+            }
+          ]
         },
         {
           "path": "./changelog/1.35.0.md",


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@coder.com>

For reference here are the two cherry-picks:

```
commit ba917ccc542fd58078a6c61397c275cda28f79a1 (HEAD -> release/1.36, origin/release/1.36)
Author: Jon Ayers <jon@coder.com>
Date:   Sun Nov 13 16:42:31 2022 -0600

    fix: prevent regular users from generating arbitrary API keys (#13355)

    - Fixes a bug where a user can generate a key for an arbitrary user
      assuming they have a reference to the user ID.

commit 769c61a5db9a5a9130b689158dc4c7cb82cf30be
Author: Spike Curtis <spike@coder.com>
Date:   Thu Oct 27 09:13:02 2022 -0700

    Use client TLS certs for Gitlab token refresh, if available (#13261)

    Signed-off-by: Spike Curtis <spike@coder.com>

    Signed-off-by: Spike Curtis <spike@coder.com>
```