### PR TITLE
Correct rsync command

### DIFF
--- a/workspaces/ssh.md
+++ b/workspaces/ssh.md
@@ -71,5 +71,5 @@ example, the following shows how you can transfer your home directory to your
 workspace:
 
 ```console
-rsync -e "coder ssh" -a --progress ~/project user@coder.<workspace-name>:~/project
+rsync -e "coder ssh" -a --progress ~/project <workspace-name>:~/project
 ```


### PR DESCRIPTION
The previous command example with `user@coder.<workspace>` does not work and gives a `fatal: failed to find workspace` error.