### PR TITLE
docs: explicitly point out the CLI is for Coder v1 and a link to v2

### DIFF
--- a/cli/index.md
+++ b/cli/index.md
@@ -3,6 +3,12 @@
 Coder provides a CLI that allows you to interact with your workspaces using your
 local machine.
 
+<blockquote class="warning">
+  <p>
+  This document refers to the Coder v1 CLI. If you landed on this page by mistake or are looking for the Coder v2 CLI, view <a href="https://coder.com/docs/v2/latest/templates#get-the-cli">the docs on how to install the Coder v2 CLI</a>. The Coder v1 CLI will not work with a Coder v2 deployment.
+  </p>
+</blockquote>
+
 <children></children>
 
 ## Full CLI reference

--- a/cli/index.md
+++ b/cli/index.md
@@ -5,7 +5,10 @@ local machine.
 
 <blockquote class="warning">
   <p>
-  This document refers to the Coder v1 CLI. If you landed on this page by mistake or are looking for the Coder v2 CLI, view <a href="https://coder.com/docs/v2/latest/templates#get-the-cli">the docs on how to install the Coder v2 CLI</a>. The Coder v1 CLI will not work with a Coder v2 deployment.
+  This document refers to the Coder v1 CLI. If you landed on this page by mistake
+  or are looking for the Coder v2 CLI, [view the docs on how to install the
+  Coder v2 CLI](https://coder.com/docs/v2/latest/templates#get-the-cli). The Coder
+  v1 CLI will not work with a Coder v2 deployment.
   </p>
 </blockquote>
 


### PR DESCRIPTION
Coder v2 users looking for the CLI often land on a Google search result which is the Coder v1 CLI, which will not work with a Coder v2 deployment.

Updated the Coder v1 docs page to clearly state this is for Coder v1 and provide a link to the Coder v2 CLI docs if they landed on the document by accident.

This has happened on several occasions where support calls with Coder personnel only uncover the mistake.