### PR TITLE
revert & fix: docs cli notice

### DIFF
--- a/cli/index.md
+++ b/cli/index.md
@@ -5,10 +5,7 @@ local machine.
 
 <blockquote class="warning">
   <p>
-  This document refers to the Coder v1 CLI. If you landed on this page by mistake
-  or are looking for the Coder v2 CLI, [view the docs on how to install the
-  Coder v2 CLI](https://coder.com/docs/v2/latest/templates#get-the-cli). The Coder
-  v1 CLI will not work with a Coder v2 deployment.
+  This document refers to the Coder v1 CLI. If you landed on this page by mistake or are looking for the Coder v2 CLI, view <a href="https://coder.com/docs/v2/latest/templates#get-the-cli">the docs on how to install the Coder v2 CLI</a>. The Coder v1 CLI will not work with a Coder v2 deployment.
   </p>
 </blockquote>
 

--- a/cli/index.md
+++ b/cli/index.md
@@ -3,6 +3,12 @@
 Coder provides a CLI that allows you to interact with your workspaces using your
 local machine.
 
+<blockquote class="warning">
+  <p>
+  This document refers to the Coder v1 CLI. If you landed on this page by mistake or are looking for the Coder v2 CLI, view <a href="https://coder.com/docs/v2/latest/templates#get-the-cli">the docs on how to install the Coder v2 CLI</a>. The Coder v1 CLI will not work with a Coder v2 deployment.
+  </p>
+</blockquote>
+
 <children></children>
 
 ## Full CLI reference

--- a/cli/index.md
+++ b/cli/index.md
@@ -5,7 +5,10 @@ local machine.
 
 <blockquote class="warning">
   <p>
-  This document refers to the Coder v1 CLI. If you landed on this page by mistake or are looking for the Coder v2 CLI, view <a href="https://coder.com/docs/v2/latest/templates#get-the-cli">the docs on how to install the Coder v2 CLI</a>. The Coder v1 CLI will not work with a Coder v2 deployment.
+  This document refers to the Coder v1 CLI. If you landed on this page by mistake
+  or are looking for the Coder v2 CLI, [view the docs on how to install the
+  Coder v2 CLI](https://coder.com/docs/v2/latest/templates#get-the-cli). The Coder
+  v1 CLI will not work with a Coder v2 deployment.
   </p>
 </blockquote>
 

--- a/cli/index.md
+++ b/cli/index.md
@@ -5,7 +5,11 @@ local machine.
 
 <blockquote class="warning">
   <p>
-  This document refers to the Coder v1 CLI. If you landed on this page by mistake or are looking for the Coder v2 CLI, view <a href="https://coder.com/docs/v2/latest/templates#get-the-cli">the docs on how to install the Coder v2 CLI</a>. The Coder v1 CLI will not work with a Coder v2 deployment.
+  This document refers to the Coder v1 CLI. If you landed on this page by mistake
+  or are looking for the Coder v2 CLI, view
+  <a href="https://coder.com/docs/v2/latest/templates#get-the-cli">the docs on
+  how to install the Coder v2 CLI</a>. The Coder v1 CLI will not work with a
+  Coder v2 deployment.
   </p>
 </blockquote>
 


### PR DESCRIPTION
this PR reverts my commit which used a markdown link inside of HTML. reverting back to the correct `<href>` syntax.