### PR TITLE
chore: add changelog for 1.43.1

### DIFF
--- a/changelog/1.43.1.md
+++ b/changelog/1.43.1.md
@@ -1,6 +1,6 @@
 ---
 title: "1.43.1"
-description: "Released on 06/15/2023"
+description: "Released on 06/26/2023"
 ---
 
 ### Breaking changes ❗

--- a/changelog/1.43.1.md
+++ b/changelog/1.43.1.md
@@ -1,0 +1,27 @@
+---
+title: "1.43.1"
+description: "Released on 06/15/2023"
+---
+
+### Breaking changes ❗
+
+- GitLab introduced a breaking change in version 14.3 where OAuth tokens without
+  expiration are no longer supported. Users who have linked their Coder account
+  to a GitLab instance version 14.3 or higher will need to un-link and re-link
+  their account.
+
+### Features ✨
+
+There are no new features in 1.43.1.
+
+### Bug fixes 🐛
+
+- infra: Fixes an issue where Coder would not update OAuth refresh tokens
+  correctly (see Breaking Changes above).
+
+### Security updates 🔐
+
+- Updated Red Hat Universal Base Image to version 8.8 to address some
+  vulnerabilities (CVE-2022-35252, CVE-2022-36227, CVE-2022-43552,
+  CVE-2023-27535).
+- Updated Go compiler to 1.20.5.

--- a/manifest.json
+++ b/manifest.json
@@ -1130,7 +1130,13 @@
           "path": "./changelog/1.43.0.md",
           "title": "1.43.0",
           "description": "Released on 05/24/2023",
-          "children": []
+          "children": [
+            {
+              "path": "./changelog/1.43.1.md",
+              "title": "1.43.1",
+              "description": "Released on 06/15/2023"
+            }
+          ]
         },
         {
           "path": "./changelog/1.42.0.md",


### PR DESCRIPTION
cherry-picked from v1.43, commits dcb822e613a95b7d7aa9dede6f8d0e9f7ab5034b and 285734afac9ed47cefd5ccab56b25eb6d35df30a