### PR TITLE
Remove mention of legacy extension marketplace

### DIFF
--- a/admin/workspace-management/ssh-access.md
+++ b/admin/workspace-management/ssh-access.md
@@ -94,7 +94,6 @@ USER=coder
 ITEM_URL=https://coder.domain.com/extensions
 CODER_IMAGE_TAG=latest
 CODER_IMAGE_DIGEST=sha256:1586122346e7d9d64a0c49a28df7538de4c5da5bfe0df672b1552dd52932c9a7
-SERVICE_URL=https://extensions.coder.com/api
 CODER_IMAGE_URI=codercom/enterprise-base:ubuntu
 PATH=/usr/local/google-cloud-sdk/bin:/home/coder/go/bin:/home/linuxbrew/.linuxbrew/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/tmp/coder/coder-cli
 BASE_PATH=/proxy/workspaces/60162f9e-78809dfc9a9e24b8f5e580ff/ide

--- a/workspaces/vs-code-extensions.md
+++ b/workspaces/vs-code-extensions.md
@@ -18,8 +18,8 @@ a Coder workspace:
 ## Using the public extensions marketplaces
 
 You can manually add an extension while you're working in the Code Web IDE. The
-extensions can be from Coder's public marketplace, Eclipse Open VSX's public
-marketplace, or the Eclipse Open VSX _local_ marketplace.
+extensions can be from Eclipse Open VSX's public marketplace or the Eclipse Open
+VSX _local_ marketplace.
 
 ![Code Web Extensions](../assets/workspaces/code-web-extensions.png)
 
@@ -85,17 +85,20 @@ marketplace:
 ## Installing from a marketplace at the command line
 
 Using the workspace's terminal or the terminal available inside Code Web (code
-server), run the following to install an extension (be sure to update the
-snippets with the name of the extension you want to install):
+server), run the following to install an extension from the currently configured
+marketplace, which defaults to Open VSX's public marketplace (be sure to update
+the snippets with the name of the extension you want to install):
 
 ```text
-SERVICE_URL=https://extensions.coder.com/api ITEM_URL=https://extensions.coder.com/item /var/tmp/coder/code-server/bin/code-server --install-extension ms-python.python
+/var/tmp/coder/code-server/bin/code-server --install-extension ms-python.python
 ```
 
-Alternatively, you can install an extension from Open VSX's public marketplace:
+To install from a different marketplace you can set the `EXTENSIONS_GALLERY`
+environment variable, which corresponds to the `extensionsGallery` entry in
+Code Web's `product.json`:
 
 ```text
-SERVICE_URL=https://open-vsx.org/vscode/gallery ITEM_URL=https://open-vsx.org/vscode/item /var/tmp/coder/code-server/bin/code-server --install-extension ms-python.python
+EXTENSIONS_GALLERY='{"serviceUrl": "https://my-extensions/api"}' /var/tmp/coder/code-server/bin/code-server --install-extension ms-python.python
 ```
 
 ## Using a local VS Code instance with SSH


### PR DESCRIPTION
We would like to get this shut down.

Also the environment variable changed a long while back.